### PR TITLE
add-showing-cards-in-a-briskula-2v2-mode

### DIFF
--- a/server/src/main/java/com/ultracards/server/controllers/games/GameController.java
+++ b/server/src/main/java/com/ultracards/server/controllers/games/GameController.java
@@ -1,19 +1,14 @@
 package com.ultracards.server.controllers.games;
 
 import com.ultracards.gateway.dto.games.GameTypeDTO;
-import com.ultracards.gateway.dto.games.games.GameCardDTO;
 import com.ultracards.gateway.dto.games.games.GameEntityDTO;
 import com.ultracards.gateway.dto.games.games.ShortGameHistoryDTO;
 import com.ultracards.gateway.dto.games.games.briskula.BriskulaGameHistoryDTO;
 import com.ultracards.server.entity.UserEntity;
-import com.ultracards.server.entity.games.PlayerEntity;
 import com.ultracards.server.entity.games.briskula.BriskulaGameEntity;
 import com.ultracards.server.service.games.briskula.BriskulaGameHistoryService;
 import com.ultracards.server.service.games.briskula.BriskulaGameService;
 import com.ultracards.server.service.games.GameManager;
-import com.ultracards.server.service.games.GameService;
-import com.ultracards.templates.game.model.AbstractPlayer;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -22,7 +17,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -32,42 +26,8 @@ import java.util.UUID;
 public class GameController {
 
     private final GameManager gameManager;
-    private final GameService gameService;
     private final BriskulaGameService briskulaGameService;
     private final BriskulaGameHistoryService briskulaGameHistoryService;
-
-    @GetMapping("/{gameId}")
-    @PreAuthorize("hasRole(T(com.ultracards.server.enums.UserRole).USER.name())")
-    public ResponseEntity<GameEntityDTO> getGameInfo(
-            @PathVariable String gameId
-    ) {
-        var game = gameManager.getGame(UUID.fromString(gameId));
-        if (game != null && game.getGameType().equals(GameTypeDTO.Briskula))
-            return ResponseEntity.ok(((BriskulaGameEntity)game).createGameDTO());
-        return ResponseEntity.notFound().build();
-    }
-    
-    @GetMapping
-    @PreAuthorize("hasRole(T(com.ultracards.server.enums.UserRole).USER.name())")
-    public ResponseEntity<List<GameCardDTO>> getPlayersCards(
-            @AuthenticationPrincipal UserEntity user
-    ) {
-        var game = gameManager.getGame(user.getId());
-        if (game != null) {
-            for (var p: game.getGame().getPlayers()) {
-                var player = (AbstractPlayer<?,?,?,?,?>) p;
-                if (((PlayerEntity) p).getUser().getId().equals(user.getId())) {
-                    var cards =  player.getHand().getCards();
-                    var res = new ArrayList<GameCardDTO>();
-                    for (var card: cards) {
-                        res.add(GameCardDTO.createCardDTO(card));
-                    }
-                    return ResponseEntity.ok(res);
-                }
-            }
-        }
-        return ResponseEntity.notFound().build();
-    }
 
     @GetMapping("/lobby/{lobbyId}")
     @PreAuthorize("hasRole(T(com.ultracards.server.enums.UserRole).USER.name())")
@@ -79,22 +39,6 @@ public class GameController {
         if (game.getGameType().equals(GameTypeDTO.Briskula))
             return ResponseEntity.ok(((BriskulaGameEntity) game).createGameDTO());
         return ResponseEntity.ok().build();
-    }
-
-    @PostMapping
-    @PreAuthorize("hasRole(T(com.ultracards.server.enums.UserRole).USER.name())")
-    public ResponseEntity<GameEntityDTO> playCard(
-            @AuthenticationPrincipal UserEntity user,
-            @Valid @RequestBody GameCardDTO card
-    ) {
-        var game = gameManager.getGame(user.getId());
-        if (game != null) {
-            gameService.playCard(user, card, game);
-            if (game.getGameType().equals(GameTypeDTO.Briskula))
-                return ResponseEntity.ok(((BriskulaGameEntity)game).createGameDTO());
-            return ResponseEntity.ok().build();
-        }
-        return ResponseEntity.notFound().build();
     }
 
     // FIXME: remove the option of deleting a game

--- a/server/src/main/java/com/ultracards/server/controllers/games/GameController.java
+++ b/server/src/main/java/com/ultracards/server/controllers/games/GameController.java
@@ -97,6 +97,7 @@ public class GameController {
         return ResponseEntity.notFound().build();
     }
 
+    // FIXME: remove the option of deleting a game
     @DeleteMapping
     @PreAuthorize("hasRole(T(com.ultracards.server.enums.UserRole).USER.name())")
     public ResponseEntity<Void> deleteGame(

--- a/server/src/main/java/com/ultracards/server/controllers/games/GameController.java
+++ b/server/src/main/java/com/ultracards/server/controllers/games/GameController.java
@@ -8,7 +8,8 @@ import com.ultracards.gateway.dto.games.games.briskula.BriskulaGameHistoryDTO;
 import com.ultracards.server.entity.UserEntity;
 import com.ultracards.server.entity.games.PlayerEntity;
 import com.ultracards.server.entity.games.briskula.BriskulaGameEntity;
-import com.ultracards.server.service.games.BriskulaGameHistoryService;
+import com.ultracards.server.service.games.briskula.BriskulaGameHistoryService;
+import com.ultracards.server.service.games.briskula.BriskulaGameService;
 import com.ultracards.server.service.games.GameManager;
 import com.ultracards.server.service.games.GameService;
 import com.ultracards.templates.game.model.AbstractPlayer;
@@ -32,6 +33,7 @@ public class GameController {
 
     private final GameManager gameManager;
     private final GameService gameService;
+    private final BriskulaGameService briskulaGameService;
     private final BriskulaGameHistoryService briskulaGameHistoryService;
 
     @GetMapping("/{gameId}")
@@ -87,7 +89,7 @@ public class GameController {
     ) {
         var game = gameManager.getGame(user.getId());
         if (game != null) {
-            gameService.playCard(user, card);
+            gameService.playCard(user, card, game);
             if (game.getGameType().equals(GameTypeDTO.Briskula))
                 return ResponseEntity.ok(((BriskulaGameEntity)game).createGameDTO());
             return ResponseEntity.ok().build();

--- a/server/src/main/java/com/ultracards/server/controllers/games/GameWsController.java
+++ b/server/src/main/java/com/ultracards/server/controllers/games/GameWsController.java
@@ -1,0 +1,34 @@
+package com.ultracards.server.controllers.games;
+
+import com.ultracards.gateway.dto.games.games.GameCardDTO;
+import com.ultracards.server.entity.games.PlayerEntity;
+import com.ultracards.server.service.games.GameManager;
+import com.ultracards.server.service.games.GameService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+import java.util.UUID;
+
+@Controller
+@RequiredArgsConstructor
+public class GameWsController {
+    private final GameManager gameManager;
+    private final GameService gameService;
+
+    @MessageMapping("/game/play")
+    public void playCard(Principal principal, @Payload @Valid GameCardDTO card) {
+        var userId = UUID.fromString(principal.getName());
+        var game = gameManager.getGame(userId);
+        if (game == null) return;
+        var user = game.getGame().getPlayers().stream()
+                .filter(p -> ((PlayerEntity) p).getUser().getId().equals(userId))
+                .map(p -> ((PlayerEntity) p).getUser())
+                .findFirst().orElse(null);
+        if (user == null) return;
+        gameService.playCard(user, card, game);
+    }
+}

--- a/server/src/main/java/com/ultracards/server/controllers/games/GameWsController.java
+++ b/server/src/main/java/com/ultracards/server/controllers/games/GameWsController.java
@@ -11,7 +11,6 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Controller;
 
 import java.security.Principal;
-import java.util.UUID;
 
 @Controller
 @RequiredArgsConstructor
@@ -21,7 +20,7 @@ public class GameWsController {
 
     @MessageMapping("/game/play")
     public void playCard(Principal principal, @Payload @Valid GameCardDTO card) {
-        var userId = UUID.fromString(principal.getName());
+        var userId = Long.valueOf(principal.getName());
         var game = gameManager.getGame(userId);
         if (game == null) return;
         var user = game.getGame().getPlayers().stream()

--- a/server/src/main/java/com/ultracards/server/entity/games/briskula/BriskulaGameEntity.java
+++ b/server/src/main/java/com/ultracards/server/entity/games/briskula/BriskulaGameEntity.java
@@ -12,20 +12,9 @@ import com.ultracards.server.entity.UserEntity;
 import com.ultracards.server.entity.games.GameEntity;
 import com.ultracards.server.entity.lobby.BriskulaLobbyGameConfig;
 import com.ultracards.templates.cards.AbstractCard;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.JoinTable;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OrderColumn;
-import jakarta.persistence.OrderBy;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.Instant;
 import java.util.*;
@@ -62,6 +51,10 @@ public class BriskulaGameEntity extends GameEntity<BriskulaGame, BriskulaLobbyGa
 
     @Column(name = "ended_at", nullable = false)
     private Instant endedAt;
+
+    @Transient
+    @Getter @Setter
+    private boolean haveTeammateCardBeenDisplayed = false;
 
     protected BriskulaGameEntity() {
     }

--- a/server/src/main/java/com/ultracards/server/service/games/GameService.java
+++ b/server/src/main/java/com/ultracards/server/service/games/GameService.java
@@ -1,199 +1,41 @@
 package com.ultracards.server.service.games;
 
-import com.ultracards.cards.ItalianCard;
 import com.ultracards.gateway.dto.games.GameTypeDTO;
 import com.ultracards.gateway.dto.games.games.GameCardDTO;
-
 import com.ultracards.server.entity.UserEntity;
 import com.ultracards.server.entity.games.GameEntity;
 import com.ultracards.server.entity.games.briskula.BriskulaGameEntity;
-import com.ultracards.server.entity.games.briskula.BriskulaPlayerEntity;
 import com.ultracards.server.entity.lobby.LobbyEntity;
-import com.ultracards.server.enums.games.GameType;
-import com.ultracards.server.repositories.games.BriskulaGameRepository;
+import com.ultracards.server.service.games.briskula.BriskulaGameService;
 import com.ultracards.server.service.lobby.LobbyManager;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Lazy;
-import org.springframework.scheduling.TaskScheduler;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.function.Function;
-
-import static com.ultracards.gateway.dto.games.games.GameEventDTO.GameEventTypeDTO.*;
 
 @Service
+@RequiredArgsConstructor
 public class GameService {
     private final GameManager gameManager;
-    private final GameEventPublisher eventPublisher;
     private final LobbyManager lobbyManager;
-    private final HashMap<Long, GameEntity<?, ?>> gameCache = new HashMap<>();
-    private final UserBriskulaStatsService userBriskulaStatsService;
-    private final UserGamesStatsService userGamesStatsService;
-    private final BriskulaGameRepository briskulaGameRepository;
-    private final TaskScheduler taskScheduler;
-    private final Function<LobbyEntity, Boolean> openLobby;
-
-    @Value("${app.briskula-move.timer.duration-seconds}")
-    private int briskulaTimerDuration;
-
-
-    public GameService(
-            GameManager gameManager,
-            GameEventPublisher eventPublisher,
-            LobbyManager lobbyManager,
-            UserBriskulaStatsService userBriskulaStatsService,
-            UserGamesStatsService userGamesStatsService,
-            BriskulaGameRepository briskulaGameRepository,
-            @Qualifier("timer")
-            TaskScheduler taskScheduler,
-            @Qualifier("openLobby") @Lazy Function<LobbyEntity, Boolean> openLobby) {
-        this.gameManager = gameManager;
-        this.eventPublisher = eventPublisher;
-        this.lobbyManager = lobbyManager;
-        this.userBriskulaStatsService = userBriskulaStatsService;
-        this.userGamesStatsService = userGamesStatsService;
-        this.briskulaGameRepository = briskulaGameRepository;
-        this.taskScheduler = taskScheduler;
-        this.openLobby = openLobby;
-    }
+    private final BriskulaGameService briskulaGameService;
 
     public GameEntity<?, ?> startGame(LobbyEntity lobby) {
         var game = gameManager.createGame(lobby.createGame());
         lobbyManager.putGame(lobby, game);
         if (game.getGameType().equals(GameTypeDTO.Briskula)) {
-            game.setTurnDurationSeconds(briskulaTimerDuration);
+            briskulaGameService.onGameStarted((BriskulaGameEntity) game);
         }
-        setTimer(game);
-        eventPublisher.publish(game, STARTED);
-        game.getPlayers().forEach(p -> gameCache.put(p.getId(), game));
         return game;
     }
 
-    public void setTimer(GameEntity<?, ?> game) {
-        if (game.getGameType().equals(GameTypeDTO.Briskula)) {
-            var briskulaGame = ((BriskulaGameEntity) game);
-            game.setTurnEndTime(Instant.now().plusSeconds(briskulaTimerDuration));
-            var prevTurnNum = game.getTurnNumber();
-            taskScheduler.schedule(() -> {
-                if (briskulaGame.getTurnNumber().equals(prevTurnNum)) {
-                    var player = briskulaGame.getCurrentPlayer();
-                    var card = GameCardDTO.createCardDTO(
-                            player.getHand().getCards().getFirst());
-                    if (card != null) {
-                        playCard(player.getUser(), card);
-
-                    }
-                }
-            }, briskulaGame.getTurnEndTime());
-        }
-    }
-
     public Optional<GameEntity<?, ?>> getGameByUser(UserEntity user) {
-        return Optional.ofNullable(gameCache.get(user.getId()));
+        return Optional.ofNullable(gameManager.getGame(user.getId()));
     }
 
-    public void playCard(UserEntity user, GameCardDTO cardDTO) {
-        var game = gameManager.getGame(user.getId());
-        var genericCard = cardDTO.toCard();
-        if (game instanceof BriskulaGameEntity game1 && genericCard instanceof ItalianCard<?>) {
-            var briskulaGame = game1.getGame();
-            var playingField = briskulaGame.getPlayingField();
-            var success = game1.playCard(user, genericCard);
-
-            if (success) {
-                var newPlayingField = briskulaGame.getPlayingField();
-                if (newPlayingField == null || newPlayingField.getPlayedCards().isEmpty()) {
-                    briskulaGame.setPlayingField(playingField);
-                    eventPublisher.publish(game, UPDATED);
-                    briskulaGame.setPlayingField(newPlayingField);
-                }
-                if (game.isActive()) {
-                    setTimer(game);
-                    eventPublisher.publish(game, UPDATED);
-                }
-                else {
-                    eventPublisher.publish(game, RESULTED);
-
-                    var winners = game1.getGame().determineGameWinners();
-                    var briskulaGameConfig = game1.getGameConfig().getGameConfig();
-                    var winnerUsers = new HashSet<UserEntity>();
-                    winners.forEach(player -> winnerUsers.add(((BriskulaPlayerEntity) player).getUser()));
-                    game.getGame().getPlayers().forEach(p -> {
-                        var player = (BriskulaPlayerEntity) p;
-                        var won = winners.contains(p);
-                        userGamesStatsService.addGame(player.getUser(), GameType.BRISKULA, won);
-                        userBriskulaStatsService.addBriskulaGame(player.getUser(), briskulaGameConfig, won);
-                    });
-                    updateBriskulaRelationshipStats(game.getPlayers(), winnerUsers, briskulaGameConfig);
-                    game1.markEnded();
-                    briskulaGameRepository.save(game1);
-
-                    game.getPlayers().forEach(p -> gameCache.remove(p.getId()));
-                    var lobby = lobbyManager.getLobby(game.getLobbyId());
-                    openLobby.apply(lobby);
-                }
-            }
-        }
-    }
-
-    private void updateBriskulaRelationshipStats(List<UserEntity> players, Set<UserEntity> winnerUsers, com.ultracards.games.briskula.BriskulaGameConfig gameConfig) {
-        var loserUsers = new ArrayList<UserEntity>();
-        for (var player : players) {
-            if (!winnerUsers.contains(player)) {
-                loserUsers.add(player);
-            }
-        }
-
-        for (var winner : winnerUsers) {
-            for (var loser : loserUsers) {
-                if (!winner.equals(loser)) {
-                    userBriskulaStatsService.addBriskulaGameAgainstUser(winner, gameConfig, loser, true);
-                    userBriskulaStatsService.addBriskulaGameAgainstUser(loser, gameConfig, winner, false);
-                }
-            }
-        }
-
-        if (gameConfig.areTeamsEnabled() && winnerUsers.size() > 1) {
-            var winnersList = new ArrayList<>(winnerUsers);
-            for (int i = 0; i < winnersList.size(); i++) {
-                for (int j = 0; j < winnersList.size(); j++) {
-                    if (i != j) {
-                        userBriskulaStatsService.addBriskulaGameWithTeammate(winnersList.get(i), gameConfig, winnersList.get(j), true);
-                    }
-                }
-            }
-        }
-
-        if (gameConfig.areTeamsEnabled()) {
-            updateBriskulaTeammatePlayedStats(players, winnerUsers, gameConfig);
-        }
-    }
-
-    private void updateBriskulaTeammatePlayedStats(List<UserEntity> players, Set<UserEntity> winnerUsers,
-                                                   com.ultracards.games.briskula.BriskulaGameConfig gameConfig) {
-        var loserUsers = new ArrayList<UserEntity>();
-        for (var player : players) {
-            if (!winnerUsers.contains(player)) {
-                loserUsers.add(player);
-            }
-        }
-
-        if (loserUsers.size() > 1) {
-            for (int i = 0; i < loserUsers.size(); i++) {
-                for (int j = 0; j < loserUsers.size(); j++) {
-                    if (i != j) {
-                        userBriskulaStatsService.addBriskulaGameWithTeammate(loserUsers.get(i), gameConfig, loserUsers.get(j), false);
-                    }
-                }
-            }
-        }
+    public void playCard(UserEntity user, @Valid GameCardDTO card, GameEntity<?, ?> game) {
+        if (game.getGameType().equals(GameTypeDTO.Briskula))
+            briskulaGameService.playCard(user, card, (BriskulaGameEntity) game);
     }
 }

--- a/server/src/main/java/com/ultracards/server/service/games/UserGamesStatsService.java
+++ b/server/src/main/java/com/ultracards/server/service/games/UserGamesStatsService.java
@@ -16,6 +16,7 @@ import com.ultracards.server.entity.games.gamestats.UserGamesStats;
 import com.ultracards.server.enums.games.GameType;
 import com.ultracards.server.repositories.UserRepository;
 import com.ultracards.server.repositories.games.UserGamesStatsRepository;
+import com.ultracards.server.service.games.briskula.UserBriskulaStatsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/server/src/main/java/com/ultracards/server/service/games/briskula/BriskulaEventPublisher.java
+++ b/server/src/main/java/com/ultracards/server/service/games/briskula/BriskulaEventPublisher.java
@@ -1,0 +1,56 @@
+package com.ultracards.server.service.games.briskula;
+
+import com.ultracards.gateway.dto.games.games.GameCardDTO;
+import com.ultracards.server.entity.UserEntity;
+import com.ultracards.server.entity.games.briskula.BriskulaGameEntity;
+import com.ultracards.server.entity.games.briskula.BriskulaPlayerEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BriskulaEventPublisher {
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public void publishTeammateHands(BriskulaGameEntity game) {
+        var teamPlayers = game.getTeamPlayers();
+        for (var p : game.getGame().getPlayers()) {
+            var player = (BriskulaPlayerEntity) p;
+            var teammateUser = determineTeammate(teamPlayers, player.getUser());
+            if (teammateUser == null) continue;
+
+            var teammatePlayer = determineLivePlayer(game, teammateUser);
+            if (teammatePlayer == null) continue;
+
+            var teammateCards = teammatePlayer.getHand().getCards().stream()
+                    .map(GameCardDTO::createCardDTO)
+                    .toList();
+
+            messagingTemplate.convertAndSendToUser(
+                    player.getUser().getId().toString(),
+                    "/queue/game/teammate-cards",
+                    teammateCards
+            );
+        }
+    }
+
+    private BriskulaPlayerEntity determineLivePlayer(BriskulaGameEntity game, UserEntity user) {
+        for (var p : game.getGame().getPlayers()) {
+            var player = (BriskulaPlayerEntity) p;
+            if (player.getUser().equals(user)) return player;
+        }
+        return null;
+    }
+
+    private UserEntity determineTeammate(List<UserEntity> teamPlayers, UserEntity user) {
+        for (int i = 0; i < teamPlayers.size(); i++) {
+            if (teamPlayers.get(i).equals(user)) {
+                return i < 2 ? teamPlayers.get(1 - i) : teamPlayers.get(5 - i);
+            }
+        }
+        return null;
+    }
+}

--- a/server/src/main/java/com/ultracards/server/service/games/briskula/BriskulaGameHistoryService.java
+++ b/server/src/main/java/com/ultracards/server/service/games/briskula/BriskulaGameHistoryService.java
@@ -1,4 +1,4 @@
-package com.ultracards.server.service.games;
+package com.ultracards.server.service.games.briskula;
 
 import com.ultracards.cards.ItalianCardSuit;
 import com.ultracards.cards.ItalianCardValue;

--- a/server/src/main/java/com/ultracards/server/service/games/briskula/BriskulaGameService.java
+++ b/server/src/main/java/com/ultracards/server/service/games/briskula/BriskulaGameService.java
@@ -37,6 +37,7 @@ import static com.ultracards.gateway.dto.games.games.GameEventDTO.GameEventTypeD
 public class BriskulaGameService {
     private final GameManager gameManager;
     private final GameEventPublisher eventPublisher;
+    private final BriskulaEventPublisher briskulaEventPublisher;
     private final LobbyManager lobbyManager;
     private final UserBriskulaStatsService userBriskulaStatsService;
     private final UserGamesStatsService userGamesStatsService;
@@ -51,6 +52,7 @@ public class BriskulaGameService {
     public BriskulaGameService(
             GameManager gameManager,
             GameEventPublisher eventPublisher,
+            BriskulaEventPublisher briskulaEventPublisher,
             LobbyManager lobbyManager,
             UserBriskulaStatsService userBriskulaStatsService,
             UserGamesStatsService userGamesStatsService,
@@ -60,6 +62,7 @@ public class BriskulaGameService {
             @Qualifier("onBriskulaCardPlayedByConfig") @Lazy Map<BriskulaGameConfig, BiFunction<UserEntity, BriskulaGameEntity, Void>> onCardPlayedByConfig) {
         this.gameManager = gameManager;
         this.eventPublisher = eventPublisher;
+        this.briskulaEventPublisher = briskulaEventPublisher;
         this.lobbyManager = lobbyManager;
         this.userBriskulaStatsService = userBriskulaStatsService;
         this.userGamesStatsService = userGamesStatsService;
@@ -78,8 +81,9 @@ public class BriskulaGameService {
         map.put(BriskulaGameConfig.FOUR_PLAYERS_NO_TEAMS, (user, game) -> null);
         map.put(BriskulaGameConfig.FOUR_PLAYERS_WITH_TEAMS, (user, game) -> {
             var briskulaGame = game.getGame();
-            if (briskulaGame.getDeck().getSize() == 0 && game.isHaveTeammateCardBeenDisplayed()) {
-                // TODO: send info per user
+            if (briskulaGame.getDeck().getSize() == 0 && !game.isHaveTeammateCardBeenDisplayed()) {
+                briskulaEventPublisher.publishTeammateHands(game);
+                game.setHaveTeammateCardBeenDisplayed(true);
             }
             return null;
         });

--- a/server/src/main/java/com/ultracards/server/service/games/briskula/BriskulaGameService.java
+++ b/server/src/main/java/com/ultracards/server/service/games/briskula/BriskulaGameService.java
@@ -1,0 +1,186 @@
+package com.ultracards.server.service.games.briskula;
+
+import com.ultracards.cards.ItalianCard;
+import com.ultracards.games.briskula.BriskulaGameConfig;
+import com.ultracards.gateway.dto.games.games.GameCardDTO;
+import com.ultracards.server.entity.UserEntity;
+import com.ultracards.server.entity.games.GameEntity;
+import com.ultracards.server.entity.games.briskula.BriskulaGameEntity;
+import com.ultracards.server.entity.games.briskula.BriskulaPlayerEntity;
+import com.ultracards.server.entity.lobby.LobbyEntity;
+import com.ultracards.server.enums.games.GameType;
+import com.ultracards.server.repositories.games.BriskulaGameRepository;
+import com.ultracards.server.service.games.GameManager;
+import com.ultracards.server.service.games.UserGamesStatsService;
+import com.ultracards.server.service.lobby.LobbyManager;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static com.ultracards.gateway.dto.games.games.GameEventDTO.GameEventTypeDTO.*;
+
+@Service
+public class BriskulaGameService {
+    private final GameManager gameManager;
+    private final GameEventPublisher eventPublisher;
+    private final LobbyManager lobbyManager;
+    private final UserBriskulaStatsService userBriskulaStatsService;
+    private final UserGamesStatsService userGamesStatsService;
+    private final BriskulaGameRepository briskulaGameRepository;
+    private final TaskScheduler taskScheduler;
+    private final Function<LobbyEntity, Boolean> openLobby;
+    private final Map<BriskulaGameConfig, BiFunction<UserEntity, BriskulaGameEntity, Void>> onCardPlayedByConfig;
+
+    @Value("${app.briskula-move.timer.duration-seconds}")
+    private int briskulaTimerDuration;
+
+    public BriskulaGameService(
+            GameManager gameManager,
+            GameEventPublisher eventPublisher,
+            LobbyManager lobbyManager,
+            UserBriskulaStatsService userBriskulaStatsService,
+            UserGamesStatsService userGamesStatsService,
+            BriskulaGameRepository briskulaGameRepository,
+            @Qualifier("timer") TaskScheduler taskScheduler,
+            @Qualifier("openLobby") @Lazy Function<LobbyEntity, Boolean> openLobby,
+            @Qualifier("onBriskulaCardPlayedByConfig") @Lazy Map<BriskulaGameConfig, BiFunction<UserEntity, BriskulaGameEntity, Void>> onCardPlayedByConfig) {
+        this.gameManager = gameManager;
+        this.eventPublisher = eventPublisher;
+        this.lobbyManager = lobbyManager;
+        this.userBriskulaStatsService = userBriskulaStatsService;
+        this.userGamesStatsService = userGamesStatsService;
+        this.briskulaGameRepository = briskulaGameRepository;
+        this.taskScheduler = taskScheduler;
+        this.openLobby = openLobby;
+        this.onCardPlayedByConfig = onCardPlayedByConfig;
+    }
+
+    @Bean("onBriskulaCardPlayedByConfig")
+    public Map<BriskulaGameConfig, BiFunction<UserEntity, BriskulaGameEntity, Void>> onBriskulaCardPlayedByConfig() {
+        var map = new EnumMap<BriskulaGameConfig, BiFunction<UserEntity, BriskulaGameEntity, Void>>(BriskulaGameConfig.class);
+        map.put(BriskulaGameConfig.TWO_PLAYERS, (user, game) -> null);
+        map.put(BriskulaGameConfig.TWO_PLAYERS_FOUR_CARDS_IN_HAND_EACH, (user, game) -> null);
+        map.put(BriskulaGameConfig.THREE_PLAYERS, (user, game) -> null);
+        map.put(BriskulaGameConfig.FOUR_PLAYERS_NO_TEAMS, (user, game) -> null);
+        map.put(BriskulaGameConfig.FOUR_PLAYERS_WITH_TEAMS, (user, game) -> {
+            var briskulaGame = game.getGame();
+            if (briskulaGame.getDeck().getSize() == 0 && game.isHaveTeammateCardBeenDisplayed()) {
+                // TODO: send info per user
+            }
+            return null;
+        });
+        return map;
+    }
+
+    public void onGameStarted(BriskulaGameEntity game) {
+        game.setTurnDurationSeconds(briskulaTimerDuration);
+        setTimer(game);
+        eventPublisher.publish(game, STARTED);
+    }
+
+    public void setTimer(BriskulaGameEntity game) {
+        game.setTurnEndTime(Instant.now().plusSeconds(briskulaTimerDuration));
+        var prevTurnNum = game.getTurnNumber();
+        taskScheduler.schedule(() -> {
+            if (game.getTurnNumber().equals(prevTurnNum)) {
+                var player = game.getCurrentPlayer();
+                var card = GameCardDTO.createCardDTO(player.getHand().getCards().getFirst());
+                if (card != null) playCard(player.getUser(), card, game);
+            }
+        }, game.getTurnEndTime());
+    }
+
+    public void playCard(UserEntity user, GameCardDTO cardDTO, BriskulaGameEntity game) {
+        var genericCard = cardDTO.toCard();
+        if (!(genericCard instanceof ItalianCard<?>)) return;
+
+        var briskulaGame = game.getGame();
+        var oldField = briskulaGame.getPlayingField();
+        if (!game.playCard(user, genericCard)) return;
+        var newField = briskulaGame.getPlayingField();
+        if (newField == null || newField.getPlayedCards().isEmpty()) {
+            briskulaGame.setPlayingField(oldField);
+            eventPublisher.publish(game, UPDATED);
+            briskulaGame.setPlayingField(newField);
+        }
+
+        if (!game.isActive()) return;
+        setTimer(game);
+        eventPublisher.publish(game, UPDATED);
+
+        onCardPlayedByConfig.get(game.getPersistedGameConfig()).apply(user, game);
+
+        handleEndGame(game);
+    }
+
+    private void handleEndGame(BriskulaGameEntity game) {
+        eventPublisher.publish(game, RESULTED);
+        var winners = game.getGame().determineGameWinners();
+        var gameConfig = game.getPersistedGameConfig();
+        var winnerUsers = new HashSet<UserEntity>();
+        winners.forEach(p -> winnerUsers.add(((BriskulaPlayerEntity) p).getUser()));
+        game.getGame().getPlayers().forEach(p -> {
+            var player = (BriskulaPlayerEntity) p;
+            var won = winners.contains(p);
+            userGamesStatsService.addGame(player.getUser(), GameType.BRISKULA, won);
+            userBriskulaStatsService.addBriskulaGame(player.getUser(), gameConfig, won);
+        });
+        updateBriskulaRelationshipStats(game.getPlayers(), winnerUsers, gameConfig);
+        game.markEnded();
+        briskulaGameRepository.save(game);
+        gameManager.deleteGame(game);
+        openLobby.apply(lobbyManager.getLobby(game.getLobbyId()));
+    }
+
+    private void updateBriskulaRelationshipStats(List<UserEntity> players, Set<UserEntity> winnerUsers,
+                                                  BriskulaGameConfig gameConfig) {
+        var loserUsers = new ArrayList<UserEntity>();
+        for (var player : players)
+            if (!winnerUsers.contains(player)) loserUsers.add(player);
+
+        for (var winner : winnerUsers)
+            for (var loser : loserUsers)
+                if (!winner.equals(loser)) {
+                    userBriskulaStatsService.addBriskulaGameAgainstUser(winner, gameConfig, loser, true);
+                    userBriskulaStatsService.addBriskulaGameAgainstUser(loser, gameConfig, winner, false);
+                }
+
+        if (gameConfig.areTeamsEnabled() && winnerUsers.size() > 1) {
+            var winnersList = new ArrayList<>(winnerUsers);
+            for (int i = 0; i < winnersList.size(); i++)
+                for (int j = 0; j < winnersList.size(); j++)
+                    if (i != j)
+                        userBriskulaStatsService.addBriskulaGameWithTeammate(winnersList.get(i), gameConfig, winnersList.get(j), true);
+        }
+
+        if (gameConfig.areTeamsEnabled())
+            updateBriskulaTeammatePlayedStats(players, winnerUsers, gameConfig);
+    }
+
+    private void updateBriskulaTeammatePlayedStats(List<UserEntity> players, Set<UserEntity> winnerUsers,
+                                                    BriskulaGameConfig gameConfig) {
+        var loserUsers = new ArrayList<UserEntity>();
+        for (var player : players)
+            if (!winnerUsers.contains(player)) loserUsers.add(player);
+
+        if (loserUsers.size() > 1)
+            for (int i = 0; i < loserUsers.size(); i++)
+                for (int j = 0; j < loserUsers.size(); j++)
+                    if (i != j)
+                        userBriskulaStatsService.addBriskulaGameWithTeammate(loserUsers.get(i), gameConfig, loserUsers.get(j), false);
+    }
+}

--- a/server/src/main/java/com/ultracards/server/service/games/briskula/BriskulaGameService.java
+++ b/server/src/main/java/com/ultracards/server/service/games/briskula/BriskulaGameService.java
@@ -15,7 +15,6 @@ import com.ultracards.server.service.games.UserGamesStatsService;
 import com.ultracards.server.service.lobby.LobbyManager;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
@@ -28,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static com.ultracards.gateway.dto.games.games.GameEventDTO.GameEventTypeDTO.*;
@@ -58,8 +56,7 @@ public class BriskulaGameService {
             UserGamesStatsService userGamesStatsService,
             BriskulaGameRepository briskulaGameRepository,
             @Qualifier("timer") TaskScheduler taskScheduler,
-            @Qualifier("openLobby") @Lazy Function<LobbyEntity, Boolean> openLobby,
-            @Qualifier("onBriskulaCardPlayedByConfig") @Lazy Map<BriskulaGameConfig, BiFunction<UserEntity, BriskulaGameEntity, Void>> onCardPlayedByConfig) {
+            @Qualifier("openLobby") @Lazy Function<LobbyEntity, Boolean> openLobby) {
         this.gameManager = gameManager;
         this.eventPublisher = eventPublisher;
         this.briskulaEventPublisher = briskulaEventPublisher;
@@ -69,11 +66,10 @@ public class BriskulaGameService {
         this.briskulaGameRepository = briskulaGameRepository;
         this.taskScheduler = taskScheduler;
         this.openLobby = openLobby;
-        this.onCardPlayedByConfig = onCardPlayedByConfig;
+        this.onCardPlayedByConfig = createOnCardPlayedByConfig();
     }
 
-    @Bean("onBriskulaCardPlayedByConfig")
-    public Map<BriskulaGameConfig, BiFunction<UserEntity, BriskulaGameEntity, Void>> onBriskulaCardPlayedByConfig() {
+    private Map<BriskulaGameConfig, BiFunction<UserEntity, BriskulaGameEntity, Void>> createOnCardPlayedByConfig() {
         var map = new EnumMap<BriskulaGameConfig, BiFunction<UserEntity, BriskulaGameEntity, Void>>(BriskulaGameConfig.class);
         map.put(BriskulaGameConfig.TWO_PLAYERS, (user, game) -> null);
         map.put(BriskulaGameConfig.TWO_PLAYERS_FOUR_CARDS_IN_HAND_EACH, (user, game) -> null);
@@ -122,13 +118,14 @@ public class BriskulaGameService {
             briskulaGame.setPlayingField(newField);
         }
 
-        if (!game.isActive()) return;
+        if (!game.isActive()) {
+            handleEndGame(game);
+            return;
+        }
         setTimer(game);
         eventPublisher.publish(game, UPDATED);
 
         onCardPlayedByConfig.get(game.getPersistedGameConfig()).apply(user, game);
-
-        handleEndGame(game);
     }
 
     private void handleEndGame(BriskulaGameEntity game) {

--- a/server/src/main/java/com/ultracards/server/service/games/briskula/GameEventPublisher.java
+++ b/server/src/main/java/com/ultracards/server/service/games/briskula/GameEventPublisher.java
@@ -1,4 +1,4 @@
-package com.ultracards.server.service.games;
+package com.ultracards.server.service.games.briskula;
 
 import com.ultracards.gateway.dto.games.GamePlayerDTO;
 import com.ultracards.gateway.dto.games.GameTypeDTO;

--- a/server/src/main/java/com/ultracards/server/service/games/briskula/GameEventPublisher.java
+++ b/server/src/main/java/com/ultracards/server/service/games/briskula/GameEventPublisher.java
@@ -2,6 +2,7 @@ package com.ultracards.server.service.games.briskula;
 
 import com.ultracards.gateway.dto.games.GamePlayerDTO;
 import com.ultracards.gateway.dto.games.GameTypeDTO;
+import com.ultracards.gateway.dto.games.games.GameCardDTO;
 import com.ultracards.gateway.dto.games.games.GameEventDTO;
 import com.ultracards.gateway.dto.games.games.briskula.BriskulaGameResultDTO;
 import com.ultracards.server.entity.games.GameEntity;
@@ -34,6 +35,19 @@ public class GameEventPublisher {
                 event.setResult(new BriskulaGameResultDTO(res, points));
             }
             messagingTemplate.convertAndSend("/topic/game/" + gameEntity.getId(), event);
+            if (!gameEventDTO.equals(GameEventTypeDTO.RESULTED)) {
+                for (var p : briskulaGame.getGame().getPlayers()) {
+                    var player = (BriskulaPlayerEntity) p;
+                    var cards = player.getHand().getCards().stream()
+                            .map(GameCardDTO::createCardDTO)
+                            .toList();
+                    messagingTemplate.convertAndSendToUser(
+                            player.getUser().getId().toString(),
+                            "/queue/game/cards",
+                            cards
+                    );
+                }
+            }
         }
     }
 }

--- a/server/src/main/java/com/ultracards/server/service/games/briskula/UserBriskulaStatsService.java
+++ b/server/src/main/java/com/ultracards/server/service/games/briskula/UserBriskulaStatsService.java
@@ -1,4 +1,4 @@
-package com.ultracards.server.service.games;
+package com.ultracards.server.service.games.briskula;
 
 import com.ultracards.games.briskula.BriskulaGameConfig;
 import com.ultracards.server.entity.UserEntity;

--- a/server/src/main/java/com/ultracards/server/service/lobby/LobbyService.java
+++ b/server/src/main/java/com/ultracards/server/service/lobby/LobbyService.java
@@ -238,8 +238,9 @@ public class LobbyService {
         var closedAt = Instant.now().plusSeconds(lobbyTimer);
         lobby.setClosedAt(closedAt);
         taskScheduler.schedule(() -> {
-            if(!lobby.isStarted() && closedAt.isBefore(Instant.now().plusSeconds(1)))
-                deleteLobby(lobby.getOwner());
+            // stale timers from previous openLobby calls see a newer closedAt and do nothing
+            if (!lobby.isStarted() && closedAt.equals(lobby.getClosedAt()))
+                deleteLobby(lobby);
         }, closedAt);
         return true;
     }

--- a/server/src/main/java/com/ultracards/server/service/users/UserService.java
+++ b/server/src/main/java/com/ultracards/server/service/users/UserService.java
@@ -4,7 +4,7 @@ import com.ultracards.gateway.dto.EmailDTO;
 import com.ultracards.server.entity.UserEntity;
 import com.ultracards.server.enums.UserRole;
 import com.ultracards.server.repositories.UserRepository;
-import com.ultracards.server.service.games.UserBriskulaStatsService;
+import com.ultracards.server.service.games.briskula.UserBriskulaStatsService;
 import com.ultracards.server.service.games.UserGamesStatsService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;

--- a/server/src/main/java/com/ultracards/ui/controllers/GameHistoryUIController.java
+++ b/server/src/main/java/com/ultracards/ui/controllers/GameHistoryUIController.java
@@ -1,7 +1,7 @@
 package com.ultracards.ui.controllers;
 
 import com.ultracards.server.entity.UserEntity;
-import com.ultracards.server.service.games.BriskulaGameHistoryService;
+import com.ultracards.server.service.games.briskula.BriskulaGameHistoryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/server/src/main/java/com/ultracards/ui/controllers/GameUIController.java
+++ b/server/src/main/java/com/ultracards/ui/controllers/GameUIController.java
@@ -1,9 +1,12 @@
 package com.ultracards.ui.controllers;
 
+import com.ultracards.gateway.dto.games.games.GameCardDTO;
 import com.ultracards.gateway.dto.games.games.GameEntityDTO;
 import com.ultracards.server.entity.UserEntity;
 import com.ultracards.server.entity.games.GameEntity;
+import com.ultracards.server.entity.games.PlayerEntity;
 import com.ultracards.server.entity.games.briskula.BriskulaGameEntity;
+import com.ultracards.templates.game.model.AbstractPlayer;
 import com.ultracards.server.service.chat.ChatService;
 import com.ultracards.server.service.games.GameService;
 import com.ultracards.server.service.lobby.LobbyService;
@@ -14,6 +17,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
 
 @Controller
 @RequestMapping("/game")
@@ -48,6 +53,7 @@ public class GameUIController {
         model.addAttribute("username", user.getUsername());
         model.addAttribute("currentUserId", user.getId());
         model.addAttribute("game", gameDto);
+        model.addAttribute("hand", toHandDto(currentGame, user));
         model.addAttribute("chat", chatService.getChat(currentLobby.getId()).toDto());
         return gameView;
     }
@@ -57,6 +63,16 @@ public class GameUIController {
             return briskulaGame.createGameDTO();
         }
         return null;
+    }
+
+    private List<GameCardDTO> toHandDto(GameEntity<?, ?> game, UserEntity user) {
+        for (var p : game.getGame().getPlayers()) {
+            var player = (AbstractPlayer<?, ?, ?, ?, ?>) p;
+            if (((PlayerEntity) p).getUser().getId().equals(user.getId())) {
+                return player.getHand().getCards().stream().map(GameCardDTO::createCardDTO).toList();
+            }
+        }
+        return List.of();
     }
 
     private String toGameView(GameEntity<?, ?> game) {

--- a/server/src/main/resources/application-dev.properties
+++ b/server/src/main/resources/application-dev.properties
@@ -20,6 +20,8 @@ logging.level.org.hibernate.orm=ERROR
 logging.level.org.hibernate.SQL=INFO
 logging.level.org.hibernate.orm.jdbc.bind=TRACE
 
+app.briskula-move.timer.duration-seconds=5
+
 # Local cookies
 app.cookie-token.secure=false
 app.cookie-token.domain=

--- a/server/src/main/resources/static/css/ui/game.css
+++ b/server/src/main/resources/static/css/ui/game.css
@@ -1607,6 +1607,150 @@
             color: var(--seat-muted);
         }
 
+        /* ===== TEAMMATE HAND BUTTON ===== */
+        /* Single static button/panel (see fragments/game/teammate-hand.html), same
+           structure as the "Last Round" button — fixed to the viewport by default,
+           absolutely positioned inside the table when included there. */
+
+        .teammate-hand-toggle {
+            /* Hidden until the server has revealed the teammate's hand. */
+            display: none;
+            position: fixed;
+            bottom: 1.3rem;
+            left: 50%;
+            transform: translateX(-50%);
+            z-index: 901;
+            padding: 0.46rem 1.05rem;
+            border-radius: 20px;
+            background: linear-gradient(155deg, #379b5a, #1d6138);
+            border: 1px solid color-mix(in oklab, #dbffe5 60%, transparent);
+            color: #f2fff5;
+            cursor: pointer;
+            font: 900 0.82rem/1 "Trebuchet MS", "Segoe UI", sans-serif;
+            text-transform: uppercase;
+            white-space: nowrap;
+            box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
+            transition: transform 200ms ease;
+        }
+
+        .teammate-hand-toggle.has-data {
+            display: inline-block;
+            animation: teammate-hand-pulse 1.6s ease-in-out infinite;
+        }
+
+        .teammate-hand-toggle:hover {
+            transform: translateX(-50%) translateY(-2px);
+        }
+
+        /* Inside the teammate's seat (renderPlayers moves it there) the button
+           anchors right above the seat's avatar. */
+        .player-seat > .teammate-hand-toggle {
+            position: absolute;
+            top: auto;
+            bottom: 100%;
+            left: 50%;
+            transform: translateX(-50%);
+            margin-bottom: 0.4rem;
+            z-index: 8;
+        }
+
+        .player-seat > .teammate-hand-toggle:hover {
+            transform: translateX(-50%) translateY(-2px);
+        }
+
+        @keyframes teammate-hand-pulse {
+            0%, 100% { box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35), 0 0 0 0 rgba(55, 155, 90, 0.55); }
+            50% { box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35), 0 0 0 8px rgba(55, 155, 90, 0); }
+        }
+
+        /* Fixed to the viewport (like .prev-round-panel) rather than confined to the
+           table, so it always paints above the hand regardless of where the toggle
+           button itself lives in the DOM. */
+        .teammate-hand-panel {
+            position: fixed;
+            bottom: 4rem;
+            left: 50%;
+            transform: translateX(-50%) translateY(10px);
+            width: max-content;
+            max-width: min(92vw, 360px);
+            background: color-mix(in oklab, var(--panel-bg) 92%, transparent);
+            border: 1px solid var(--panel-border);
+            border-radius: 16px;
+            padding: 0.7rem 0.8rem;
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 180ms ease, transform 180ms ease;
+            z-index: 950;
+            box-shadow: var(--panel-shadow);
+            backdrop-filter: blur(16px);
+        }
+
+        /* Inside the table the panel anchors below the top toggle, mirroring the
+           prev-round panel that anchors above its bottom toggle. */
+        .table-surface > .teammate-hand-panel {
+            position: absolute;
+            left: 50%;
+            top: 11%;
+            bottom: auto;
+            width: max-content;
+            max-width: calc(100vw - 2rem);
+            z-index: 9;
+        }
+
+        .teammate-hand-panel.is-open {
+            opacity: 1;
+            pointer-events: auto;
+            transform: translateX(-50%) translateY(0);
+        }
+
+        .teammate-hand-title {
+            font-size: 0.72rem;
+            font-weight: 900;
+            text-transform: uppercase;
+            text-align: center;
+            color: var(--seat-muted);
+            margin-bottom: 0.4rem;
+        }
+
+        .teammate-hand-cards {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+            justify-content: center;
+        }
+
+        .teammate-hand-card-img {
+            width: clamp(52px, 6vh, 72px);
+            aspect-ratio: 300 / 546;
+            height: auto;
+            border-radius: 8px;
+            overflow: hidden;
+            box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);
+            position: relative;
+            transition: transform 160ms ease;
+        }
+
+        /* Enlarged card pops out over the panel edges (panel/cards keep default
+           overflow: visible, so nothing clips it). */
+        .teammate-hand-card-img:hover {
+            transform: scale(2);
+            z-index: 5;
+            box-shadow: 0 12px 26px rgba(0, 0, 0, 0.4);
+        }
+
+        .teammate-hand-card-img .card-front,
+        .teammate-hand-card-img .card-back {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            border-radius: 6px;
+        }
+
+        .teammate-hand-empty {
+            font-size: 0.68rem;
+            color: var(--seat-muted);
+        }
+
         @media (prefers-reduced-motion: reduce) {
             .card-inner {
                 transition-duration: 80ms !important;

--- a/server/src/main/resources/static/js/ui/games/briskula.js
+++ b/server/src/main/resources/static/js/ui/games/briskula.js
@@ -98,7 +98,9 @@
             hands: {
                 self: null,
                 table: null
-            }
+            },
+            teammateCards: null,
+            teammateAutoCloseTimer: null
         };
         const PreviousRoundStore = {
             save(id, data) {
@@ -106,6 +108,29 @@
             },
             load(id) {
                 try { return JSON.parse(localStorage.getItem('uc-prev-round-' + id)); } catch (e) { return null; }
+            }
+        };
+        // Teammate hand only needs to survive this one game, so it's session-scoped
+        // (not localStorage like the previous-round history) and erased when the game ends.
+        const TeammateHandStore = {
+            keyFor(id) { return 'uc-teammate-hand-' + id; },
+            save(id, cards) {
+                try { sessionStorage.setItem(this.keyFor(id), JSON.stringify(cards)); } catch (e) {}
+            },
+            load(id) {
+                try { return JSON.parse(sessionStorage.getItem(this.keyFor(id))); } catch (e) { return null; }
+            },
+            clear(id) {
+                try { sessionStorage.removeItem(this.keyFor(id)); } catch (e) {}
+            },
+            // Drop any leftover entries from other games in this tab's session.
+            clearStale(currentId) {
+                try {
+                    const keep = this.keyFor(currentId);
+                    Array.from({length: sessionStorage.length}, (_, i) => sessionStorage.key(i))
+                        .filter((k) => k && k.startsWith('uc-teammate-hand-') && k !== keep)
+                        .forEach((k) => sessionStorage.removeItem(k));
+                } catch (e) {}
             }
         };
 
@@ -117,11 +142,108 @@
             prevRoundToggle.addEventListener('click', () => {
                 const open = prevRoundPanel.classList.toggle('is-open');
                 prevRoundToggle.setAttribute('aria-expanded', String(open));
-                if (open) renderPrevRoundPanel();
+                if (open) {
+                    closeTeammateHandPanel();
+                    renderPrevRoundPanel();
+                }
             });
         }
 
-        // The "Last Round" button only appears once a completed round is stored.
+        function closePrevRoundPanel() {
+            if (!prevRoundPanel) return;
+            prevRoundPanel.classList.remove('is-open');
+            prevRoundToggle?.setAttribute('aria-expanded', 'false');
+        }
+
+        const teammateHandToggle = document.getElementById('teammate-hand-toggle');
+        const teammateHandPanel = document.getElementById('teammate-hand-panel');
+        const teammateHandCardsEl = document.getElementById('teammate-hand-cards');
+
+        if (teammateHandToggle && teammateHandPanel) {
+            teammateHandToggle.addEventListener('click', () => {
+                // Clicking while the auto-preview timer is running just pins the panel
+                // open (cancels the auto-close) instead of toggling it shut.
+                if (state.teammateAutoCloseTimer) {
+                    clearTimeout(state.teammateAutoCloseTimer);
+                    state.teammateAutoCloseTimer = null;
+                    return;
+                }
+                if (teammateHandPanel.classList.contains('is-open')) {
+                    closeTeammateHandPanel();
+                } else {
+                    openTeammateHandPanel(false);
+                }
+            });
+        }
+
+        // The teammate-hand button only appears once the server has revealed it.
+        function refreshTeammateHandButton() {
+            const hasData = Array.isArray(state.teammateCards) && state.teammateCards.length > 0;
+            teammateHandToggle?.classList.toggle('has-data', hasData);
+        }
+
+        function clearTeammateHand() {
+            state.teammateCards = null;
+            TeammateHandStore.clear(gameId);
+            refreshTeammateHandButton();
+            closeTeammateHandPanel();
+        }
+
+        function closeTeammateHandPanel() {
+            if (state.teammateAutoCloseTimer) {
+                clearTimeout(state.teammateAutoCloseTimer);
+                state.teammateAutoCloseTimer = null;
+            }
+            teammateHandPanel?.classList.remove('is-open');
+            teammateHandToggle?.setAttribute('aria-expanded', 'false');
+        }
+
+        // autoClose: true when triggered by the WS reveal itself (self-closes after a
+        // couple seconds unless the player clicks the button, which pins it open).
+        function openTeammateHandPanel(autoClose) {
+            if (!teammateHandPanel || !teammateHandToggle) return;
+            closePrevRoundPanel();
+            teammateHandPanel.classList.add('is-open');
+            teammateHandToggle.setAttribute('aria-expanded', 'true');
+            renderTeammateHandPanel();
+            if (state.teammateAutoCloseTimer) {
+                clearTimeout(state.teammateAutoCloseTimer);
+                state.teammateAutoCloseTimer = null;
+            }
+            if (autoClose) {
+                state.teammateAutoCloseTimer = setTimeout(() => {
+                    state.teammateAutoCloseTimer = null;
+                    closeTeammateHandPanel();
+                }, 2500);
+            }
+        }
+
+        function renderTeammateHandPanel() {
+            const el = teammateHandCardsEl;
+            if (!el) return;
+            const cards = Array.isArray(state.teammateCards) ? state.teammateCards : [];
+            el.innerHTML = '';
+            if (!cards.length) {
+                el.innerHTML = '<span class="teammate-hand-empty">No cards to show</span>';
+                return;
+            }
+            cards.forEach((card, i) => {
+                const wrap = window.UltracardsGameUi?.renderCardImage({
+                    card,
+                    className: 'teammate-hand-card-img',
+                    alt: `Teammate card ${i + 1}`
+                });
+                if (wrap) {
+                    el.appendChild(wrap);
+                } else {
+                    const img = document.createElement('img');
+                    window.UltracardsGameUi?.applyCardImage(img, window.UltracardsGameUi?.cardUrl(card) || '');
+                    img.alt = `Teammate card ${i + 1}`;
+                    el.appendChild(img);
+                }
+            });
+        }
+
         function refreshPrevRoundButton() {
             if (!prevRoundToggle) return;
             const data = PreviousRoundStore.load(gameId);
@@ -188,8 +310,6 @@
             });
         }
 
-        let refreshTimer = null;
-        let refreshAttempts = 0;
         const chat = window.UltracardsChat?.create({
             initialChat,
             currentUserId,
@@ -254,8 +374,16 @@
             applyGame(initialGame, 'UPDATED', null);
         }
         refreshPrevRoundButton();
-        refreshHand();
-        loadGame();
+        TeammateHandStore.clearStale(gameId);
+        state.teammateCards = TeammateHandStore.load(gameId);
+        // The server reveals teammate hands only once the deck is exhausted, so a
+        // cached hand while the deck still has cards is stale — erase it.
+        if (state.teammateCards && Number(state.deckLeft) > 0) {
+            state.teammateCards = null;
+            TeammateHandStore.clear(gameId);
+        }
+        refreshTeammateHandButton();
+        applyHand(window.__INITIAL_HAND__ || []);
         connectWs();
 
         function connectWs() {
@@ -283,6 +411,23 @@
                         applyGame(payload.gameEntity, payload.gameEvent, payload.result);
                     } catch (err) {
                         console.error('Game event error', err);
+                    }
+                });
+                client.subscribe('/user/queue/game/cards', (msg) => {
+                    try {
+                        applyHand(JSON.parse(msg.body));
+                    } catch (err) {
+                        console.error('Hand event error', err);
+                    }
+                });
+                client.subscribe('/user/queue/game/teammate-cards', (msg) => {
+                    try {
+                        state.teammateCards = JSON.parse(msg.body) || [];
+                        TeammateHandStore.save(gameId, state.teammateCards);
+                        refreshTeammateHandButton();
+                        openTeammateHandPanel(true);
+                    } catch (err) {
+                        console.error('Teammate hand event error', err);
                     }
                 });
                 if (initialGame?.lobbyId) {
@@ -319,77 +464,38 @@
             }
         }
 
-        function loadGame() {
-            fetch(`/api/games/${gameId}`, {credentials: 'include'})
-                .then((res) => res.ok ? res.json() : Promise.reject(res.status))
-                .then((game) => {
-                    if (game) applyGame(game, 'UPDATED', null);
-                })
-        }
-
-        function refreshHand() {
+        function applyHand(cards) {
             if (!dom.hand) return;
-            fetch('/api/games', {credentials: 'include'})
-                .then((res) => res.ok ? res.json() : Promise.reject(res.status))
-                .then((cards) => {
-                    const list = Array.isArray(cards) ? cards : [];
-                    const prevKeys = new Set(state.hand.map(cardKey));
-                    const serverKeys = new Set(list.map(cardKey));
-                    const newCards = [];
-                    state.pending.forEach((key) => {
-                        if (!serverKeys.has(key)) {
-                            state.pending.delete(key);
-                        }
-                    });
-                    state.autoPlayedPending.forEach((key) => {
-                        if (!serverKeys.has(key)) {
-                            state.autoPlayedPending.delete(key);
-                        }
-                    });
-                    list.forEach((card) => {
-                        const key = cardKey(card);
-                        if (!prevKeys.has(key)) {
-                            state.justDealtKeys.add(key);
-                            // Mark as dealing BEFORE syncHand so the card is created
-                            // face-down and excluded from the generic fade-in.
-                            state.dealingKeys.add(key);
-                            newCards.push(card);
-                        }
-                    });
-                    state.hand = list.filter((card) => !state.pending.has(cardKey(card)));
-                    syncHand();
-                    if (newCards.length) {
-                        dealCardsIntoHand(newCards, state.finalTrumpDraw);
-                        state.finalTrumpDraw = false;
-                    }
-                    if (!state.pending.size && refreshTimer) {
-                        clearTimeout(refreshTimer);
-                        refreshTimer = null;
-                        refreshAttempts = 0;
-                    }
-                })
-                .catch(() => {
-                    if (refreshTimer) {
-                        clearTimeout(refreshTimer);
-                        refreshTimer = null;
-                        refreshAttempts = 0;
-                    }
-                });
-        }
-
-        function scheduleHandRefresh(attempts) {
-            if (attempts && attempts > refreshAttempts) refreshAttempts = attempts;
-            if (refreshTimer) return;
-            const run = () => {
-                if (refreshAttempts <= 0) {
-                    refreshTimer = null;
-                    return;
+            const list = Array.isArray(cards) ? cards : [];
+            const prevKeys = new Set(state.hand.map(cardKey));
+            const serverKeys = new Set(list.map(cardKey));
+            const newCards = [];
+            state.pending.forEach((key) => {
+                if (!serverKeys.has(key)) {
+                    state.pending.delete(key);
                 }
-                refreshAttempts -= 1;
-                refreshHand();
-                refreshTimer = setTimeout(run, 900);
-            };
-            refreshTimer = setTimeout(run, 350);
+            });
+            state.autoPlayedPending.forEach((key) => {
+                if (!serverKeys.has(key)) {
+                    state.autoPlayedPending.delete(key);
+                }
+            });
+            list.forEach((card) => {
+                const key = cardKey(card);
+                if (!prevKeys.has(key)) {
+                    state.justDealtKeys.add(key);
+                    // Mark as dealing BEFORE syncHand so the card is created
+                    // face-down and excluded from the generic fade-in.
+                    state.dealingKeys.add(key);
+                    newCards.push(card);
+                }
+            });
+            state.hand = list.filter((card) => !state.pending.has(cardKey(card)));
+            syncHand();
+            if (newCards.length) {
+                dealCardsIntoHand(newCards, state.finalTrumpDraw);
+                state.finalTrumpDraw = false;
+            }
         }
 
         /**
@@ -458,12 +564,7 @@
                 renderPlayers(game);
                 updateTurnIndicator(game);
                 renderCurrentPlayer(game);
-                if (prevDeckLeft != null && prevDeckLeft > nextDeckLeft) {
-                    // Opponent draws fly in via syncBackCards (renderPlayers above).
-                    if (currentUserId) scheduleHandRefresh(4);
-                }
                 updateTurn(game.playersTurn);
-                if (state.pending.size) scheduleHandRefresh(4);
                 if (state.delayedTablePending) {
                     return;
                 }
@@ -508,18 +609,12 @@
             const autoplayedCard = detectAutoPlayedCard(previousPlayedCards, nextPlayedCards);
             if (autoplayedCard) {
                 animateAutoPlayedHandRemoval(autoplayedCard);
-                scheduleHandRefresh(4);
             }
             renderTrick(nextPlayedCards, previousPlayedCards);
             renderPlayers(game);
             updateTurnIndicator(game);
             renderCurrentPlayer(game);
-            if (prevDeckLeft != null && prevDeckLeft > nextDeckLeft) {
-                // Opponent draws fly in via syncBackCards (renderPlayers above).
-                if (currentUserId) scheduleHandRefresh(4);
-            }
             updateTurn(game.playersTurn);
-            if (state.pending.size) scheduleHandRefresh(4);
             if (gameEvent === 'RESULTED' && result && Array.isArray(result.gameWinners)) {
                 const winners = formatWinnerText(result.gameWinners, game);
                 state.endState = {
@@ -529,6 +624,7 @@
                 };
                 renderCenterResult(state.endState.title, state.endState.winnersText, state.endState.metaText);
                 startLobbyReturnCountdown();
+                clearTeammateHand();
             } else if (gameEvent === 'CLOSED') {
                 state.endState = {
                     title: 'Match Result',
@@ -537,6 +633,7 @@
                 };
                 renderCenterResult(state.endState.title, state.endState.winnersText, state.endState.metaText);
                 startLobbyReturnCountdown();
+                clearTeammateHand();
             } else if (state.endState) {
                 renderCenterResult(state.endState.title, state.endState.winnersText, state.endState.metaText);
             } else {
@@ -893,6 +990,11 @@
                 seat.classList.remove('team-seat-ally', 'team-seat-enemy', 'team-seat-neutral');
                 seat.classList.remove('team-seat-1', 'team-seat-2');
                 seat.classList.add(`team-seat-${teamTone}`);
+                // The teammate-hand toggle lives inside the teammate's seat, right
+                // above the avatar (moved, not cloned — listeners stay attached).
+                if (teamTone === 'ally' && !isSelf && teammateHandToggle && teammateHandToggle.parentElement !== seat) {
+                    seat.insertBefore(teammateHandToggle, seat.firstChild);
+                }
                 if (teamNumber != null) {
                     seat.classList.add(`team-seat-${teamNumber}`);
                 }
@@ -1121,43 +1223,26 @@
             }
             state.playing = true;
             state.pending.add(cardKey(card));
-            fetch('/api/games', {
-                method: 'POST',
-                credentials: 'include',
-                headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({cardType: card.cardType, card: card.card})
-            })
-                .then(async (res) => {
-                    if (!res.ok) {
-                        const text = await res.text();
-                        throw new Error(text || `play failed: ${res.status}`);
-                    }
-                    return res.json().catch(() => null);
-                })
-                .then((game) => {
-                    state.playing = false;
-                    animateHandRemoval(cardKey(card));
-                    setTimeout(() => {
-                        state.hand = state.hand.filter((entry) => cardKey(entry) !== cardKey(card));
-                        syncHand();
-                    }, 230);
-                    if (game) {
-                        applyGame(game, 'UPDATED', null);
-                    }
-                    scheduleHandRefresh(6);
-                })
-                .catch((err) => {
-                    state.playing = false;
-                    state.pending.delete(cardKey(card));
-                    // Play rejected: discard the flown real card so it doesn't linger,
-                    // then re-create the card cleanly in the hand.
-                    if (state.justPlayed && state.justPlayed.key === cardKey(card)) {
-                        state.justPlayed.el?.remove();
-                        state.justPlayed = null;
-                    }
-                    restoreDraggedCard(cardKey(card));
-                    syncHand();
-                });
+            if (!state.wsClient || !state.wsConnected) {
+                state.playing = false;
+                state.pending.delete(cardKey(card));
+                // No live connection: discard the flown real card so it doesn't linger,
+                // then re-create the card cleanly in the hand.
+                if (state.justPlayed && state.justPlayed.key === cardKey(card)) {
+                    state.justPlayed.el?.remove();
+                    state.justPlayed = null;
+                }
+                restoreDraggedCard(cardKey(card));
+                syncHand();
+                return;
+            }
+            state.wsClient.send('/app/game/play', {}, JSON.stringify({cardType: card.cardType, card: card.card}));
+            state.playing = false;
+            animateHandRemoval(cardKey(card));
+            setTimeout(() => {
+                state.hand = state.hand.filter((entry) => cardKey(entry) !== cardKey(card));
+                syncHand();
+            }, 230);
         }
 
         function setTableDropReady(on) {

--- a/server/src/main/resources/templates/ui/fragments/game/table.html
+++ b/server/src/main/resources/templates/ui/fragments/game/table.html
@@ -14,6 +14,7 @@
                 <div th:id="${idPrefix + 'table-turn-message'}" class="table-turn-message">Waiting for the next move</div>
             </div>
             <th:block th:replace="~{ui/fragments/game/previous-round :: previousRound(null)}"></th:block>
+            <th:block th:replace="~{ui/fragments/game/teammate-hand :: teammateHand(null)}"></th:block>
             <div class="table-center">
                 <div th:id="${idPrefix + 'trick-area'}"
                      class="trick-area"

--- a/server/src/main/resources/templates/ui/fragments/game/teammate-hand.html
+++ b/server/src/main/resources/templates/ui/fragments/game/teammate-hand.html
@@ -1,0 +1,11 @@
+<th:block th:fragment="teammateHand(gameId)" xmlns:th="http://www.thymeleaf.org">
+    <button class="teammate-hand-toggle" id="teammate-hand-toggle" type="button" aria-expanded="false">
+        Teammate Hand
+    </button>
+    <div class="teammate-hand-panel" id="teammate-hand-panel" role="region" aria-label="Teammate's hand">
+        <div class="teammate-hand-title">Teammate's Hand</div>
+        <div class="teammate-hand-cards" id="teammate-hand-cards">
+            <span class="teammate-hand-empty">No cards to show</span>
+        </div>
+    </div>
+</th:block>

--- a/server/src/main/resources/templates/ui/games/briskula.html
+++ b/server/src/main/resources/templates/ui/games/briskula.html
@@ -40,6 +40,7 @@
 <div th:replace="~{ui/fragments/footer :: footer}"></div>
 <script th:inline="javascript">
     window.__INITIAL_GAME__ = /*[[${game}]]*/ null;
+    window.__INITIAL_HAND__ = /*[[${hand}]]*/ null;
     window.__INITIAL_GAME_CHAT__ = /*[[${chat}]]*/ null;
 </script>
 <script src="https://cdn.jsdelivr.net/npm/gsap@3.12.7/dist/gsap.min.js"></script>


### PR DESCRIPTION
- Separated briskula game logic from generic game service into dedicated per-game-type services/entities, added websocket endpoints for game events (GameController.java, GameWsController.java, BriskulaGameService.java).
- Added server-side support for showing teammates' cards in 2v2 briskula mode, including new BriskulaEventPublisher and updated hand/card handling.
- Refactored briskula game logic out of GameService into BriskulaGameService, trimming the general service down and cleaning up controller card handling.
- Built the UI for the teammate-hand display (new teammate-hand.html fragment, game.css styling, and briskula.js client logic updates).
- Minor stats/lobby service wiring updates to support the new per-game-type structure.