### PR TITLE
Implemented game-gateway services

### DIFF
--- a/game-gateway/README.md
+++ b/game-gateway/README.md
@@ -1,6 +1,71 @@
-# `game-gateway` module
+# game-gateway
 
-## Overview
+DTOs and client services for UI apps that talk to the ULTRACARDS server.
 
-- `game-gateway` is a module that provides a gateway for ui to connect to game servers.
-- Dependencies are not yet implemented.
+## Quick Start
+
+```java
+var client = new GatewayAppClient(
+        "http://localhost:8080/",
+        "ws://localhost:8080/ws"
+);
+
+var profile = client.profile().getProfile();
+var lobbies = client.lobby().getLobbies();
+```
+
+Service groups:
+
+- REST: `authentication`, `profile`, `lobby`, `game`, `friend`, `chat`, `notification`, `users`, `cards`, `server`, `uiPages`
+- WS: `gameSocket`, `lobbySocket`, `chatSocket`, `notificationSocket`
+
+## JavaFX Calls
+
+Keep server calls off the UI thread:
+
+```java
+var async = GatewayAsync.cached(Platform::runLater);
+var client = new GatewayAppClient(restTemplate, serverUrl, wsUrl, tokenHolder, async);
+
+var request = client.async().call(() -> client.profile().getProfile());
+client.async().onUi(request, profile -> {
+    usernameLabel.setText(profile.getUsername());
+}, error -> {
+    errorLabel.setText(error.getMessage());
+});
+```
+
+## State
+
+Use `GatewayState<T>` for view-model state. `listen` returns a `GatewayListener` cleanup handle.
+
+```java
+var lobbyState = new GatewayState<GameLobbyDTO>();
+var listener = lobbyState.listen(lobby -> renderLobby(lobby));
+
+lobbyState.set(client.lobby().getLobby());
+listener.close();
+```
+
+## WebSockets
+
+Track subscriptions with `GatewaySocketHandle`, then close once when the screen closes.
+
+```java
+client.gameSocket().thenAccept(gameSocket -> {
+    var handle = new GatewaySocketHandle(gameSocket::close);
+
+    handle.track(gameSocket.subscribeToGame(gameId, event -> gameState.set(event.getGameEntity())));
+    handle.track(gameSocket.subscribeToCards(cards -> handState.set(cards)));
+    gameSocket.playCard(card);
+
+    // later: handle.close();
+});
+```
+
+## Checks
+
+```bash
+mvn -pl game-gateway -am test
+java -ea -cp game-gateway/target/test-classes:game-gateway/target/classes com.ultracards.gateway.app.GatewayTest
+```

--- a/game-gateway/src/main/java/com/ultracards/gateway/app/GatewayAppClient.java
+++ b/game-gateway/src/main/java/com/ultracards/gateway/app/GatewayAppClient.java
@@ -1,0 +1,145 @@
+package com.ultracards.gateway.app;
+
+import com.ultracards.gateway.service.AuthenticationService;
+import com.ultracards.gateway.service.CardImageService;
+import com.ultracards.gateway.service.ChatService;
+import com.ultracards.gateway.service.ChatWsService;
+import com.ultracards.gateway.service.ClientTokenHolder;
+import com.ultracards.gateway.service.FriendService;
+import com.ultracards.gateway.service.GameService;
+import com.ultracards.gateway.service.GameWsService;
+import com.ultracards.gateway.service.LobbyService;
+import com.ultracards.gateway.service.LobbyWsService;
+import com.ultracards.gateway.service.NotificationService;
+import com.ultracards.gateway.service.NotificationWsService;
+import com.ultracards.gateway.service.ProfileService;
+import com.ultracards.gateway.service.ServerService;
+import com.ultracards.gateway.service.StompGatewayService;
+import com.ultracards.gateway.service.UiPageService;
+import com.ultracards.gateway.service.UserSearchService;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.concurrent.CompletableFuture;
+
+public class GatewayAppClient implements AutoCloseable {
+    private final ClientTokenHolder tokenHolder;
+    private final String wsUrl;
+    private final GatewayAsync async;
+    private final AuthenticationService authentication;
+    private final ProfileService profile;
+    private final LobbyService lobby;
+    private final GameService game;
+    private final FriendService friend;
+    private final ChatService chat;
+    private final NotificationService notification;
+    private final UserSearchService users;
+    private final CardImageService cards;
+    private final ServerService server;
+    private final UiPageService uiPages;
+
+    public GatewayAppClient(String serverUrl, String wsUrl) {
+        this(new RestTemplate(), serverUrl, wsUrl, new ClientTokenHolder(), GatewayAsync.cached(Runnable::run));
+    }
+
+    public GatewayAppClient(
+            RestTemplate restTemplate,
+            String serverUrl,
+            String wsUrl,
+            ClientTokenHolder tokenHolder,
+            GatewayAsync async
+    ) {
+        this.tokenHolder = tokenHolder;
+        this.wsUrl = wsUrl;
+        this.async = async;
+        this.authentication = new AuthenticationService(restTemplate, serverUrl, tokenHolder);
+        this.profile = new ProfileService(restTemplate, serverUrl, tokenHolder);
+        this.lobby = new LobbyService(restTemplate, serverUrl, tokenHolder);
+        this.game = new GameService(restTemplate, serverUrl, tokenHolder);
+        this.friend = new FriendService(restTemplate, serverUrl, tokenHolder);
+        this.chat = new ChatService(restTemplate, serverUrl, tokenHolder);
+        this.notification = new NotificationService(restTemplate, serverUrl, tokenHolder);
+        this.users = new UserSearchService(restTemplate, serverUrl);
+        this.cards = new CardImageService(restTemplate, serverUrl, tokenHolder);
+        this.server = new ServerService(restTemplate, serverUrl);
+        this.uiPages = new UiPageService(restTemplate, serverUrl, tokenHolder);
+    }
+
+    public GatewayAsync async() {
+        return async;
+    }
+
+    public ClientTokenHolder tokenHolder() {
+        return tokenHolder;
+    }
+
+    public AuthenticationService authentication() {
+        return authentication;
+    }
+
+    public ProfileService profile() {
+        return profile;
+    }
+
+    public LobbyService lobby() {
+        return lobby;
+    }
+
+    public GameService game() {
+        return game;
+    }
+
+    public FriendService friend() {
+        return friend;
+    }
+
+    public ChatService chat() {
+        return chat;
+    }
+
+    public NotificationService notification() {
+        return notification;
+    }
+
+    public UserSearchService users() {
+        return users;
+    }
+
+    public CardImageService cards() {
+        return cards;
+    }
+
+    public ServerService server() {
+        return server;
+    }
+
+    public UiPageService uiPages() {
+        return uiPages;
+    }
+
+    public CompletableFuture<GameWsService> gameSocket() {
+        return connect(new GameWsService(wsUrl, tokenHolder));
+    }
+
+    public CompletableFuture<LobbyWsService> lobbySocket() {
+        return connect(new LobbyWsService(wsUrl, tokenHolder));
+    }
+
+    public CompletableFuture<ChatWsService> chatSocket() {
+        return connect(new ChatWsService(wsUrl, tokenHolder));
+    }
+
+    public CompletableFuture<NotificationWsService> notificationSocket() {
+        return connect(new NotificationWsService(wsUrl, tokenHolder));
+    }
+
+    private <T extends StompGatewayService> CompletableFuture<T> connect(T socket) {
+        var ready = new CompletableFuture<T>();
+        socket.connect(() -> ready.complete(socket), ready::completeExceptionally);
+        return ready;
+    }
+
+    @Override
+    public void close() {
+        async.close();
+    }
+}

--- a/game-gateway/src/main/java/com/ultracards/gateway/app/GatewayAsync.java
+++ b/game-gateway/src/main/java/com/ultracards/gateway/app/GatewayAsync.java
@@ -1,0 +1,65 @@
+package com.ultracards.gateway.app;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public class GatewayAsync implements AutoCloseable {
+    private final Executor background;
+    private final Consumer<Runnable> ui;
+    private final boolean ownsBackground;
+
+    public GatewayAsync(Executor background, Consumer<Runnable> ui) {
+        this(background, ui, false);
+    }
+
+    private GatewayAsync(Executor background, Consumer<Runnable> ui, boolean ownsBackground) {
+        this.background = background;
+        this.ui = ui;
+        this.ownsBackground = ownsBackground;
+    }
+
+    public static GatewayAsync cached(Consumer<Runnable> ui) {
+        return new GatewayAsync(Executors.newCachedThreadPool(), ui, true);
+    }
+
+    public static GatewayAsync direct() {
+        return new GatewayAsync(Runnable::run, Runnable::run);
+    }
+
+    public <T> CompletableFuture<T> call(Supplier<T> supplier) {
+        return CompletableFuture.supplyAsync(supplier, background);
+    }
+
+    public CompletableFuture<Void> run(Runnable action) {
+        return CompletableFuture.runAsync(action, background);
+    }
+
+    public <T> void onUi(
+            CompletableFuture<T> future,
+            Consumer<T> onSuccess,
+            Consumer<Throwable> onError
+    ) {
+        future.whenComplete((value, error) -> ui.accept(() -> {
+            if (error == null) {
+                onSuccess.accept(value);
+            } else if (onError != null) {
+                onError.accept(unwrap(error));
+            }
+        }));
+    }
+
+    private Throwable unwrap(Throwable error) {
+        return error.getCause() != null ? error.getCause() : error;
+    }
+
+    @Override
+    public void close() {
+        if (ownsBackground && background instanceof ExecutorService service) {
+            service.shutdownNow();
+        }
+    }
+}

--- a/game-gateway/src/main/java/com/ultracards/gateway/app/GatewayListener.java
+++ b/game-gateway/src/main/java/com/ultracards/gateway/app/GatewayListener.java
@@ -1,0 +1,7 @@
+package com.ultracards.gateway.app;
+
+@FunctionalInterface
+public interface GatewayListener extends AutoCloseable {
+    @Override
+    void close();
+}

--- a/game-gateway/src/main/java/com/ultracards/gateway/app/GatewaySocketHandle.java
+++ b/game-gateway/src/main/java/com/ultracards/gateway/app/GatewaySocketHandle.java
@@ -1,0 +1,30 @@
+package com.ultracards.gateway.app;
+
+import org.springframework.messaging.simp.stomp.StompSession;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class GatewaySocketHandle implements AutoCloseable {
+    private final List<GatewaySubscription> subscriptions = new CopyOnWriteArrayList<>();
+    private final Runnable disconnect;
+
+    public GatewaySocketHandle(Runnable disconnect) {
+        this.disconnect = disconnect;
+    }
+
+    public GatewaySubscription track(StompSession.Subscription subscription) {
+        var tracked = GatewaySubscription.of(subscription);
+        subscriptions.add(tracked);
+        return tracked;
+    }
+
+    @Override
+    public void close() {
+        for (var subscription : subscriptions) {
+            subscription.close();
+        }
+        subscriptions.clear();
+        disconnect.run();
+    }
+}

--- a/game-gateway/src/main/java/com/ultracards/gateway/app/GatewayState.java
+++ b/game-gateway/src/main/java/com/ultracards/gateway/app/GatewayState.java
@@ -1,0 +1,33 @@
+package com.ultracards.gateway.app;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+public class GatewayState<T> {
+    private final List<Consumer<T>> listeners = new CopyOnWriteArrayList<>();
+    private volatile T value;
+
+    public GatewayState() {
+    }
+
+    public GatewayState(T value) {
+        this.value = value;
+    }
+
+    public T get() {
+        return value;
+    }
+
+    public void set(T value) {
+        this.value = value;
+        for (var listener : listeners) {
+            listener.accept(value);
+        }
+    }
+
+    public GatewayListener listen(Consumer<T> listener) {
+        listeners.add(listener);
+        return () -> listeners.remove(listener);
+    }
+}

--- a/game-gateway/src/main/java/com/ultracards/gateway/app/GatewaySubscription.java
+++ b/game-gateway/src/main/java/com/ultracards/gateway/app/GatewaySubscription.java
@@ -1,0 +1,22 @@
+package com.ultracards.gateway.app;
+
+import org.springframework.messaging.simp.stomp.StompSession;
+
+public class GatewaySubscription implements AutoCloseable {
+    private final StompSession.Subscription subscription;
+
+    private GatewaySubscription(StompSession.Subscription subscription) {
+        this.subscription = subscription;
+    }
+
+    public static GatewaySubscription of(StompSession.Subscription subscription) {
+        return new GatewaySubscription(subscription);
+    }
+
+    @Override
+    public void close() {
+        if (subscription != null) {
+            subscription.unsubscribe();
+        }
+    }
+}

--- a/game-gateway/src/main/java/com/ultracards/gateway/service/AuthenticationService.java
+++ b/game-gateway/src/main/java/com/ultracards/gateway/service/AuthenticationService.java
@@ -30,7 +30,7 @@ public class AuthenticationService {
                                  ClientTokenHolder clientTokenHolder,
                                  TokenManager tokenManager) {
         this.restTemplate = restTemplate;
-        this.serverUrl = serverUrl;
+        this.serverUrl = serverUrl.endsWith("/") ? serverUrl : serverUrl + "/";
         this.clientTokenHolder = clientTokenHolder;
         this.tokenManager = tokenManager;
     }
@@ -53,7 +53,7 @@ public class AuthenticationService {
             @NotBlank String username) {
         var entity = new HttpEntity<>(new UsernameDTO(username), tokenManager.authHeaders(tokenHolder));
         var response = restTemplate.exchange(
-                serverUrl + "api/auth/username",
+                serverUrl + "api/profile/username",
                 HttpMethod.PUT,
                 entity,
                 UsernameDTO.class
@@ -66,7 +66,7 @@ public class AuthenticationService {
     public UsernameDTO getUsername (@NotNull ClientTokenHolder tokenHolder) {
         var entity = new HttpEntity<>(tokenManager.authHeaders(tokenHolder));
         var response = restTemplate.exchange(
-                serverUrl + "api/auth/username",
+                serverUrl + "api/profile/username",
                 HttpMethod.GET,
                 entity,
                 UsernameDTO.class
@@ -140,7 +140,7 @@ public class AuthenticationService {
         var entity = new HttpEntity<>(tokenManager.authHeaders(tokenHolder));
 
         var response = restTemplate.exchange(
-                serverUrl + "api/auth/profile",
+                serverUrl + "api/profile",
                 HttpMethod.GET,
                 entity,
                 ProfileDTO.class
@@ -161,7 +161,7 @@ public class AuthenticationService {
     ) {
         var entity = new HttpEntity<>(profileDTO, tokenManager.jsonHeaders(tokenHolder));
         var response = restTemplate.postForEntity(
-                serverUrl + "api/auth/profile",
+                serverUrl + "api/profile",
                 entity,
                 ProfileDTO.class
         );

--- a/game-gateway/src/main/java/com/ultracards/gateway/service/CardImageService.java
+++ b/game-gateway/src/main/java/com/ultracards/gateway/service/CardImageService.java
@@ -1,0 +1,60 @@
+package com.ultracards.gateway.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class CardImageService {
+    private final RestTemplate restTemplate;
+    private final String serverUrl;
+    private final ClientTokenHolder tokenHolder;
+    private final TokenManager tokenManager;
+
+    @Autowired
+    public CardImageService(RestTemplate restTemplate,
+                            @Qualifier("serverUrl") String serverUrl,
+                            ClientTokenHolder tokenHolder,
+                            TokenManager tokenManager) {
+        this.restTemplate = restTemplate;
+        this.serverUrl = serverUrl.endsWith("/") ? serverUrl : serverUrl + "/";
+        this.tokenHolder = tokenHolder;
+        this.tokenManager = tokenManager;
+    }
+
+    public CardImageService(RestTemplate restTemplate,
+                            @Qualifier("serverUrl") String serverUrl,
+                            ClientTokenHolder tokenHolder) {
+        this(restTemplate, serverUrl, tokenHolder, new TokenManager(tokenHolder));
+    }
+
+    public byte[] italianCard(String suit, String value) {
+        return card("italian/" + suit + "/" + value);
+    }
+
+    public byte[] italianCardBack() {
+        return card("italian/back");
+    }
+
+    public byte[] pokerCard(String suit, String value) {
+        return card("poker/" + suit + "/" + value);
+    }
+
+    public byte[] pokerCardBack() {
+        return card("poker/back");
+    }
+
+    private byte[] card(String path) {
+        var response = restTemplate.exchange(
+                serverUrl + "api/cards/" + path,
+                HttpMethod.GET,
+                new HttpEntity<>(tokenManager.authHeaders(tokenHolder)),
+                byte[].class
+        );
+        tokenManager.updateToken(tokenHolder, response);
+        return response.getBody();
+    }
+}

--- a/game-gateway/src/main/java/com/ultracards/gateway/service/ChatService.java
+++ b/game-gateway/src/main/java/com/ultracards/gateway/service/ChatService.java
@@ -1,28 +1,24 @@
 package com.ultracards.gateway.service;
 
-import com.ultracards.gateway.dto.games.games.GameEntityDTO;
-import com.ultracards.gateway.dto.games.games.ShortGameHistoryDTO;
-import com.ultracards.gateway.dto.games.games.briskula.BriskulaGameHistoryDTO;
+import com.ultracards.gateway.dto.games.chat.ChatDTO;
+import com.ultracards.gateway.dto.games.chat.ChatMessageDTO;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.List;
-import java.util.UUID;
-
 @Service
-public class GameService {
+public class ChatService {
     private final RestTemplate restTemplate;
     private final String serverUrl;
     private final ClientTokenHolder tokenHolder;
     private final TokenManager tokenManager;
 
     @Autowired
-    public GameService(RestTemplate restTemplate,
+    public ChatService(RestTemplate restTemplate,
                        @Qualifier("serverUrl") String serverUrl,
                        ClientTokenHolder tokenHolder,
                        TokenManager tokenManager) {
@@ -32,61 +28,61 @@ public class GameService {
         this.tokenManager = tokenManager;
     }
 
-    public GameService(RestTemplate restTemplate,
+    public ChatService(RestTemplate restTemplate,
                        @Qualifier("serverUrl") String serverUrl,
                        ClientTokenHolder tokenHolder) {
         this(restTemplate, serverUrl, tokenHolder, new TokenManager(tokenHolder));
     }
 
-    public BriskulaGameHistoryDTO getGame(UUID gameId) {
-        return getGameHistory(gameId);
-    }
-
-    public BriskulaGameHistoryDTO getGameHistory(UUID gameId) {
+    public ChatDTO getLobbyChat() {
         var response = restTemplate.exchange(
-                serverUrl + "api/games/history/" + gameId,
+                serverUrl + "api/chat",
                 HttpMethod.GET,
                 new HttpEntity<>(tokenManager.authHeaders(tokenHolder)),
-                BriskulaGameHistoryDTO.class
+                ChatDTO.class
         );
         tokenManager.updateToken(tokenHolder, response);
         return response.getBody();
     }
 
-    public GameEntityDTO getGameByLobby(UUID lobbyId) {
-        var response = restTemplate.exchange(
-                serverUrl + "api/games/lobby/" + lobbyId,
-                HttpMethod.GET,
-                new HttpEntity<>(tokenManager.authHeaders(tokenHolder)),
-                GameEntityDTO.class
-        );
-        tokenManager.updateToken(tokenHolder, response);
-        return response.getBody();
-    }
-
-    public List<ShortGameHistoryDTO> getPastGames() {
-        return getPastGames(0, "both", "latest");
-    }
-
-    public List<ShortGameHistoryDTO> getPastGames(int offset, String result, String timeSort) {
-        var response = restTemplate.exchange(
-                serverUrl + "api/games/history?offset=" + offset + "&result=" + result + "&timeSort=" + timeSort,
-                HttpMethod.GET,
-                new HttpEntity<>(tokenManager.authHeaders(tokenHolder)),
-                new ParameterizedTypeReference<List<ShortGameHistoryDTO>>() {}
-        );
-        tokenManager.updateToken(tokenHolder, response);
-        return response.getBody();
-    }
-
-    public boolean deleteGame() {
-        var response = restTemplate.exchange(
-                serverUrl + "api/games",
-                HttpMethod.DELETE,
-                new HttpEntity<>(tokenManager.authHeaders(tokenHolder)),
+    public boolean sendLobbyMessage(@Valid ChatMessageDTO message) {
+        var response = restTemplate.postForEntity(
+                serverUrl + "api/chat",
+                new HttpEntity<>(message, tokenManager.jsonHeaders(tokenHolder)),
                 Void.class
         );
         tokenManager.updateToken(tokenHolder, response);
         return response.getStatusCode().is2xxSuccessful();
+    }
+
+    public ChatDTO getFriendChat(Long friendUserId) {
+        var response = restTemplate.exchange(
+                serverUrl + "api/chat/friends/" + friendUserId,
+                HttpMethod.GET,
+                new HttpEntity<>(tokenManager.authHeaders(tokenHolder)),
+                ChatDTO.class
+        );
+        tokenManager.updateToken(tokenHolder, response);
+        return response.getBody();
+    }
+
+    public ChatDTO sendFriendMessage(Long friendUserId, @Valid ChatMessageDTO message) {
+        var response = restTemplate.postForEntity(
+                serverUrl + "api/chat/friends/" + friendUserId,
+                new HttpEntity<>(message, tokenManager.jsonHeaders(tokenHolder)),
+                ChatDTO.class
+        );
+        tokenManager.updateToken(tokenHolder, response);
+        return response.getBody();
+    }
+
+    public ChatDTO readAllFriendMessages(Long friendUserId) {
+        var response = restTemplate.postForEntity(
+                serverUrl + "api/chat/friends/" + friendUserId + "/read-all",
+                new HttpEntity<>(tokenManager.authHeaders(tokenHolder)),
+                ChatDTO.class
+        );
+        tokenManager.updateToken(tokenHolder, response);
+        return response.getBody();
     }
 }

--- a/game-gateway/src/main/java/com/ultracards/gateway/service/ChatWsService.java
+++ b/game-gateway/src/main/java/com/ultracards/gateway/service/ChatWsService.java
@@ -1,0 +1,30 @@
+package com.ultracards.gateway.service;
+
+import com.ultracards.gateway.dto.games.chat.ChatMessageDTO;
+import org.springframework.messaging.simp.stomp.StompSession;
+
+import java.util.UUID;
+import java.util.function.Consumer;
+
+public class ChatWsService extends StompGatewayService {
+
+    public ChatWsService(String wsUrl, ClientTokenHolder tokenHolder) {
+        super(wsUrl, tokenHolder);
+    }
+
+    public ChatWsService(String wsUrl, ClientTokenHolder tokenHolder, TokenManager tokenManager) {
+        super(wsUrl, tokenHolder, tokenManager);
+    }
+
+    public StompSession.Subscription subscribeToLobbyChat(UUID lobbyId, Consumer<ChatMessageDTO> handler) {
+        return subscribe("/topic/lobbies/" + lobbyId + "/chat", ChatMessageDTO.class, handler);
+    }
+
+    public StompSession.Subscription subscribeToFriendChat(UUID chatId, Consumer<ChatMessageDTO> handler) {
+        return subscribe("/topic/friends/chats/" + chatId, ChatMessageDTO.class, handler);
+    }
+
+    public StompSession.Subscription subscribeToFriendChatNotifications(Consumer<ChatMessageDTO> handler) {
+        return subscribe("/user/queue/friends/chat", ChatMessageDTO.class, handler);
+    }
+}

--- a/game-gateway/src/main/java/com/ultracards/gateway/service/FriendService.java
+++ b/game-gateway/src/main/java/com/ultracards/gateway/service/FriendService.java
@@ -50,6 +50,10 @@ public class FriendService {
     }
 
     public List<FriendDTO> getBlockedFriends() {
+        return getBlockedUsers();
+    }
+
+    public List<FriendDTO> getBlockedUsers() {
         var response = restTemplate.exchange(
                 serverUrl + "api/friends/blocked",
                 HttpMethod.GET,

--- a/game-gateway/src/main/java/com/ultracards/gateway/service/GameWsService.java
+++ b/game-gateway/src/main/java/com/ultracards/gateway/service/GameWsService.java
@@ -1,107 +1,37 @@
 package com.ultracards.gateway.service;
 
+import com.ultracards.gateway.dto.games.games.GameCardDTO;
 import com.ultracards.gateway.dto.games.games.GameEventDTO;
-import org.springframework.messaging.converter.JacksonJsonMessageConverter;
-import org.springframework.messaging.simp.stomp.StompFrameHandler;
-import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.messaging.simp.stomp.StompSession;
-import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
-import org.springframework.messaging.simp.stomp.StompSession.Subscription;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-import org.springframework.web.socket.WebSocketHttpHeaders;
-import org.springframework.web.socket.client.standard.StandardWebSocketClient;
-import org.springframework.web.socket.messaging.WebSocketStompClient;
 
-import java.lang.reflect.Type;
-import java.net.URI;
+import java.util.List;
 import java.util.UUID;
 import java.util.function.Consumer;
 
-/**
- * WebSocket client for game-specific events. Clients can subscribe to `/topic/lobbies/{gameId}`.
- *
- * Incomplete implementation. Do not use in production.
- */
-@Deprecated
-public class GameWsService {
-
-    private final WebSocketStompClient stompClient;
-    private final String wsUrl;
-    private final ClientTokenHolder tokenHolder;
-    private final TokenManager tokenManager;
-    private StompSession session;
+public class GameWsService extends StompGatewayService {
 
     public GameWsService(String wsUrl, ClientTokenHolder tokenHolder) {
-        this(wsUrl, tokenHolder, new TokenManager(tokenHolder));
+        super(wsUrl, tokenHolder);
     }
 
     public GameWsService(String wsUrl, ClientTokenHolder tokenHolder, TokenManager tokenManager) {
-        this.wsUrl = wsUrl;
-        this.tokenHolder = tokenHolder;
-        this.tokenManager = tokenManager;
-        this.stompClient = new WebSocketStompClient(new StandardWebSocketClient());
-        var scheduler = new ThreadPoolTaskScheduler();
-        scheduler.initialize();
-        this.stompClient.setTaskScheduler(scheduler);
-        this.stompClient.setMessageConverter(new JacksonJsonMessageConverter());
+        super(wsUrl, tokenHolder, tokenManager);
     }
 
-    /**
-     * Establishes a STOMP session with cookie-based authentication.
-     */
-    public void connect(Runnable onConnected, Consumer<Throwable> onError) {
-        var headers = new WebSocketHttpHeaders();
-        var token = tokenManager != null ? tokenManager.tokenValue(tokenHolder) :
-                (tokenHolder != null ? tokenHolder.getToken() : null);
-        if (token != null) {
-            headers.add("Cookie", "refreshToken=" + token);
-        }
-        stompClient.connectAsync(URI.create(wsUrl).toString(), headers, new StompSessionHandlerAdapter() {
-            @Override
-            public void afterConnected(StompSession stompSession, StompHeaders connectedHeaders) {
-                session = stompSession;
-                if (onConnected != null) {
-                    onConnected.run();
-                }
-            }
-
-            @Override
-            public void handleTransportError(StompSession stompSession, Throwable ex) {
-                if (onError != null) {
-                    onError.accept(ex);
-                }
-            }
-        });
+    public void playCard(GameCardDTO card) {
+        send("/app/game/play", card);
     }
 
-    public Subscription subscribeToGame(UUID gameId, Consumer<GameEventDTO> handler) {
-        ensureSession();
-        return subscribeDestination("/topic/lobbies/" + gameId, handler);
+    public StompSession.Subscription subscribeToGame(UUID gameId, Consumer<GameEventDTO> handler) {
+        return subscribe("/topic/game/" + gameId, GameEventDTO.class, handler);
     }
 
-    public void disconnect() {
-        if (session != null && session.isConnected()) {
-            session.disconnect();
-        }
+    public StompSession.Subscription subscribeToCards(Consumer<List<GameCardDTO>> handler) {
+        return subscribe("/user/queue/game/cards", new ParameterizedTypeReference<List<GameCardDTO>>() {}, handler);
     }
 
-    private Subscription subscribeDestination(String destination, Consumer<GameEventDTO> handler) {
-        return session.subscribe(destination, new StompFrameHandler() {
-            @Override
-            public Type getPayloadType(StompHeaders headers) {
-                return GameEventDTO.class;
-            }
-
-            @Override
-            public void handleFrame(StompHeaders headers, Object payload) {
-                handler.accept((GameEventDTO) payload);
-            }
-        });
-    }
-
-    private void ensureSession() {
-        if (session == null || !session.isConnected()) {
-            throw new IllegalStateException("WebSocket session is not connected; call connect() first.");
-        }
+    public StompSession.Subscription subscribeToTeammateCards(Consumer<List<GameCardDTO>> handler) {
+        return subscribe("/user/queue/game/teammate-cards", new ParameterizedTypeReference<List<GameCardDTO>>() {}, handler);
     }
 }

--- a/game-gateway/src/main/java/com/ultracards/gateway/service/LobbyService.java
+++ b/game-gateway/src/main/java/com/ultracards/gateway/service/LobbyService.java
@@ -4,6 +4,7 @@ import com.ultracards.gateway.dto.games.lobby.GameLobbyDTO;
 import com.ultracards.gateway.dto.games.lobby.JoinLobbyRequestDTO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
@@ -40,6 +41,17 @@ public class LobbyService {
         var res = restTemplate.postForEntity(
                 serverUrl + "api/lobby/create",
                 new HttpEntity<>(gameLobbyDTO, tokenManager.jsonHeaders(tokenHolder)),
+                GameLobbyDTO.class
+        );
+        tokenManager.updateToken(tokenHolder, res);
+        return res.getBody();
+    }
+
+    public GameLobbyDTO getLobby() {
+        var res = restTemplate.exchange(
+                serverUrl + "api/lobby/get",
+                HttpMethod.GET,
+                new HttpEntity<>(tokenManager.authHeaders(tokenHolder)),
                 GameLobbyDTO.class
         );
         tokenManager.updateToken(tokenHolder, res);
@@ -132,7 +144,18 @@ public class LobbyService {
                 serverUrl + "api/lobby/get-lobbies",
                 HttpMethod.GET,
                 new HttpEntity<>(tokenManager.authHeaders(tokenHolder)),
-                new org.springframework.core.ParameterizedTypeReference<List<GameLobbyDTO>>() {}
+                new ParameterizedTypeReference<List<GameLobbyDTO>>() {}
+        );
+        tokenManager.updateToken(tokenHolder, res);
+        return res.getBody();
+    }
+
+    public List<GameLobbyDTO> getLobbies(String gameType, Integer gameSettingId) {
+        var res = restTemplate.exchange(
+                serverUrl + "api/lobby/get-lobbies/" + gameType + "/" + gameSettingId,
+                HttpMethod.GET,
+                new HttpEntity<>(tokenManager.authHeaders(tokenHolder)),
+                new ParameterizedTypeReference<List<GameLobbyDTO>>() {}
         );
         tokenManager.updateToken(tokenHolder, res);
         return res.getBody();

--- a/game-gateway/src/main/java/com/ultracards/gateway/service/LobbyWsService.java
+++ b/game-gateway/src/main/java/com/ultracards/gateway/service/LobbyWsService.java
@@ -1,114 +1,31 @@
 package com.ultracards.gateway.service;
 
 import com.ultracards.gateway.dto.games.lobby.GameLobbyEventDTO;
-import org.springframework.messaging.converter.JacksonJsonMessageConverter;
-import org.springframework.messaging.simp.stomp.StompFrameHandler;
-import org.springframework.messaging.simp.stomp.StompHeaders;
 import org.springframework.messaging.simp.stomp.StompSession;
-import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-import org.springframework.web.socket.WebSocketHttpHeaders;
-import org.springframework.web.socket.client.standard.StandardWebSocketClient;
-import org.springframework.web.socket.messaging.WebSocketStompClient;
 
-import java.lang.reflect.Type;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
 
-/**
- * STOMP client for lobby lifecycle updates (CREATED, UPDATED, DELETED, STARTED).
- * Connect once, then subscribe to lobby topics to receive {@link GameLobbyEventDTO} notifications.
- * Incomplete implementation. Do not use in production.
- */
-@Deprecated
-public class LobbyWsService {
-
-    private final WebSocketStompClient stompClient;
-    private final String wsUrl; // e.g., ws://host:port/ws
-    private final ClientTokenHolder tokenHolder;
-    private final TokenManager tokenManager;
-    private StompSession session;
+public class LobbyWsService extends StompGatewayService {
 
     public LobbyWsService(String wsUrl, ClientTokenHolder tokenHolder) {
-        this(wsUrl, tokenHolder, new TokenManager(tokenHolder));
+        super(wsUrl, tokenHolder);
     }
 
     public LobbyWsService(String wsUrl, ClientTokenHolder tokenHolder, TokenManager tokenManager) {
-        this.wsUrl = wsUrl;
-        this.tokenHolder = tokenHolder;
-        this.tokenManager = tokenManager;
-        this.stompClient = new WebSocketStompClient(new StandardWebSocketClient());
-        var scheduler = new ThreadPoolTaskScheduler();
-        scheduler.initialize();
-        this.stompClient.setTaskScheduler(scheduler);
-        this.stompClient.setMessageConverter(new JacksonJsonMessageConverter());
+        super(wsUrl, tokenHolder, tokenManager);
     }
 
-    public void connect(Runnable onConnected, Consumer<Throwable> onError) {
-        var headers = new WebSocketHttpHeaders();
-        var token = tokenManager != null ? tokenManager.tokenValue(tokenHolder) :
-                (tokenHolder != null ? tokenHolder.getToken() : null);
-        if (token != null) {
-            headers.add("Cookie", "refreshToken=" + token);
-        }
-        stompClient.connectAsync(URI.create(wsUrl).toString(), headers, new StompSessionHandlerAdapter() {
-            @Override
-            public void afterConnected(StompSession s, StompHeaders connectedHeaders) {
-                session = s;
-                if (onConnected != null) onConnected.run();
-            }
-
-            @Override
-            public void handleTransportError(StompSession s, Throwable ex) {
-                if (onError != null) onError.accept(ex);
-            }
-        });
+    public StompSession.Subscription subscribeToLobbies(Consumer<GameLobbyEventDTO> handler) {
+        return subscribe("/topic/lobbies", GameLobbyEventDTO.class, handler);
     }
 
-    /**
-     * Subscribe to global lobby events published to /topic/lobbies.
-     */
-    public List<StompSession.Subscription> subscribeToLobbies(Consumer<GameLobbyEventDTO> handler) {
-        ensureSession();
-        var subs = new ArrayList<StompSession.Subscription>(1);
-        subs.add(subscribeDestination("/topic/lobbies", handler));
-        return subs;
-    }
-
-    /**
-     * Subscribe to a specific lobby channel (e.g., updates scoped to a lobby id).
-     */
     public StompSession.Subscription subscribeToLobby(UUID lobbyId, Consumer<GameLobbyEventDTO> handler) {
-        ensureSession();
-        return subscribeDestination("/topic/lobbies/" + lobbyId, handler);
+        return subscribe("/topic/lobbies/" + lobbyId, GameLobbyEventDTO.class, handler);
     }
 
-    private StompSession.Subscription subscribeDestination(String destination, Consumer<GameLobbyEventDTO> handler) {
-        return session.subscribe(destination, new StompFrameHandler() {
-            @Override
-            public Type getPayloadType(StompHeaders headers) {
-                return GameLobbyEventDTO.class;
-            }
-
-            @Override
-            public void handleFrame(StompHeaders headers, Object payload) {
-                handler.accept((GameLobbyEventDTO) payload);
-            }
-        });
-    }
-
-    private void ensureSession() {
-        if (session == null || !session.isConnected()) {
-            throw new IllegalStateException("WebSocket session is not connected; call connect() first.");
-        }
-    }
-
-    public void disconnect() {
-        if (session != null && session.isConnected()) {
-            session.disconnect();
-        }
+    public StompSession.Subscription subscribeToLobbyGameId(UUID lobbyId, Consumer<Map> handler) {
+        return subscribe("/topic/lobbies/" + lobbyId, Map.class, handler);
     }
 }

--- a/game-gateway/src/main/java/com/ultracards/gateway/service/NotificationService.java
+++ b/game-gateway/src/main/java/com/ultracards/gateway/service/NotificationService.java
@@ -1,0 +1,109 @@
+package com.ultracards.gateway.service;
+
+import com.ultracards.gateway.dto.notifications.NotificationDTO;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class NotificationService {
+    private final RestTemplate restTemplate;
+    private final String serverUrl;
+    private final ClientTokenHolder tokenHolder;
+    private final TokenManager tokenManager;
+
+    @Autowired
+    public NotificationService(RestTemplate restTemplate,
+                               @Qualifier("serverUrl") String serverUrl,
+                               ClientTokenHolder tokenHolder,
+                               TokenManager tokenManager) {
+        this.restTemplate = restTemplate;
+        this.serverUrl = serverUrl.endsWith("/") ? serverUrl : serverUrl + "/";
+        this.tokenHolder = tokenHolder;
+        this.tokenManager = tokenManager;
+    }
+
+    public NotificationService(RestTemplate restTemplate,
+                               @Qualifier("serverUrl") String serverUrl,
+                               ClientTokenHolder tokenHolder) {
+        this(restTemplate, serverUrl, tokenHolder, new TokenManager(tokenHolder));
+    }
+
+    public List<NotificationDTO> getNotifications() {
+        return getNotifications("");
+    }
+
+    public List<NotificationDTO> getUnreadNotifications() {
+        return getNotifications("/unread");
+    }
+
+    public NotificationDTO sendTextNotificationToUser(Long recipientUserId, @NotBlank String message) {
+        var response = restTemplate.postForEntity(
+                serverUrl + "api/notifications/text/users/" + recipientUserId,
+                new HttpEntity<>(message, tokenManager.jsonHeaders(tokenHolder)),
+                NotificationDTO.class
+        );
+        tokenManager.updateToken(tokenHolder, response);
+        return response.getBody();
+    }
+
+    public List<NotificationDTO> sendTextNotificationToAll(@NotBlank String message) {
+        var response = restTemplate.exchange(
+                serverUrl + "api/notifications/text/all",
+                HttpMethod.POST,
+                new HttpEntity<>(message, tokenManager.jsonHeaders(tokenHolder)),
+                new ParameterizedTypeReference<List<NotificationDTO>>() {}
+        );
+        tokenManager.updateToken(tokenHolder, response);
+        return response.getBody();
+    }
+
+    public NotificationDTO markRead(UUID id) {
+        return patch(id, "read");
+    }
+
+    public NotificationDTO markUnread(UUID id) {
+        return patch(id, "unread");
+    }
+
+    public boolean deleteNotification(UUID id) {
+        var response = restTemplate.exchange(
+                serverUrl + "api/notifications/" + id,
+                HttpMethod.DELETE,
+                new HttpEntity<>(tokenManager.authHeaders(tokenHolder)),
+                Void.class
+        );
+        tokenManager.updateToken(tokenHolder, response);
+        return response.getStatusCode().is2xxSuccessful();
+    }
+
+    private List<NotificationDTO> getNotifications(String path) {
+        var response = restTemplate.exchange(
+                serverUrl + "api/notifications" + path,
+                HttpMethod.GET,
+                new HttpEntity<>(tokenManager.authHeaders(tokenHolder)),
+                new ParameterizedTypeReference<List<NotificationDTO>>() {}
+        );
+        tokenManager.updateToken(tokenHolder, response);
+        return response.getBody();
+    }
+
+    private NotificationDTO patch(UUID id, String action) {
+        var response = restTemplate.exchange(
+                serverUrl + "api/notifications/" + id + "/" + action,
+                HttpMethod.PATCH,
+                new HttpEntity<>(tokenManager.authHeaders(tokenHolder)),
+                NotificationDTO.class
+        );
+        tokenManager.updateToken(tokenHolder, response);
+        return response.getBody();
+    }
+}

--- a/game-gateway/src/main/java/com/ultracards/gateway/service/NotificationWsService.java
+++ b/game-gateway/src/main/java/com/ultracards/gateway/service/NotificationWsService.java
@@ -1,93 +1,21 @@
 package com.ultracards.gateway.service;
 
 import com.ultracards.gateway.dto.notifications.NotificationDTO;
-import org.springframework.messaging.converter.JacksonJsonMessageConverter;
-import org.springframework.messaging.simp.stomp.StompFrameHandler;
-import org.springframework.messaging.simp.stomp.StompHeaders;
 import org.springframework.messaging.simp.stomp.StompSession;
-import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-import org.springframework.web.socket.WebSocketHttpHeaders;
-import org.springframework.web.socket.client.standard.StandardWebSocketClient;
-import org.springframework.web.socket.messaging.WebSocketStompClient;
 
-import java.lang.reflect.Type;
-import java.net.URI;
 import java.util.function.Consumer;
 
-/**
- * STOMP client for user-scoped notification updates.
- * Incomplete implementation. Do not use in production.
- */
-@Deprecated
-public class NotificationWsService {
-
-    private final WebSocketStompClient stompClient;
-    private final String wsUrl;
-    private final ClientTokenHolder tokenHolder;
-    private final TokenManager tokenManager;
-    private StompSession session;
+public class NotificationWsService extends StompGatewayService {
 
     public NotificationWsService(String wsUrl, ClientTokenHolder tokenHolder) {
-        this(wsUrl, tokenHolder, new TokenManager(tokenHolder));
+        super(wsUrl, tokenHolder);
     }
 
     public NotificationWsService(String wsUrl, ClientTokenHolder tokenHolder, TokenManager tokenManager) {
-        this.wsUrl = wsUrl;
-        this.tokenHolder = tokenHolder;
-        this.tokenManager = tokenManager;
-        this.stompClient = new WebSocketStompClient(new StandardWebSocketClient());
-        var scheduler = new ThreadPoolTaskScheduler();
-        scheduler.initialize();
-        this.stompClient.setTaskScheduler(scheduler);
-        this.stompClient.setMessageConverter(new JacksonJsonMessageConverter());
-    }
-
-    public void connect(Runnable onConnected, Consumer<Throwable> onError) {
-        var headers = new WebSocketHttpHeaders();
-        var token = tokenManager != null ? tokenManager.tokenValue(tokenHolder) :
-                (tokenHolder != null ? tokenHolder.getToken() : null);
-        if (token != null)
-            headers.add("Cookie", "refreshToken=" + token);
-
-        stompClient.connectAsync(URI.create(wsUrl).toString(), headers, new StompSessionHandlerAdapter() {
-            @Override
-            public void afterConnected(StompSession stompSession, StompHeaders connectedHeaders) {
-                session = stompSession;
-                if (onConnected != null)
-                    onConnected.run();
-            }
-
-            @Override
-            public void handleTransportError(StompSession stompSession, Throwable ex) {
-                if (onError != null)
-                    onError.accept(ex);
-            }
-        });
+        super(wsUrl, tokenHolder, tokenManager);
     }
 
     public StompSession.Subscription subscribeToNotifications(Consumer<NotificationDTO> handler) {
-        ensureSession();
-        return session.subscribe("/user/queue/notifications", new StompFrameHandler() {
-            @Override
-            public Type getPayloadType(StompHeaders headers) {
-                return NotificationDTO.class;
-            }
-
-            @Override
-            public void handleFrame(StompHeaders headers, Object payload) {
-                handler.accept((NotificationDTO) payload);
-            }
-        });
-    }
-
-    public void disconnect() {
-        if (session != null && session.isConnected())
-            session.disconnect();
-    }
-
-    private void ensureSession() {
-        if (session == null || !session.isConnected())
-            throw new IllegalStateException("WebSocket session is not connected; call connect() first.");
+        return subscribe("/user/queue/notifications", NotificationDTO.class, handler);
     }
 }

--- a/game-gateway/src/main/java/com/ultracards/gateway/service/ProfileService.java
+++ b/game-gateway/src/main/java/com/ultracards/gateway/service/ProfileService.java
@@ -1,0 +1,118 @@
+package com.ultracards.gateway.service;
+
+import com.ultracards.gateway.dto.auth.DetailedProfileStatsDTO;
+import com.ultracards.gateway.dto.auth.ProfileDTO;
+import com.ultracards.gateway.dto.auth.UserSessionDTO;
+import com.ultracards.gateway.dto.auth.UsernameDTO;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+@Service
+public class ProfileService {
+    private final RestTemplate restTemplate;
+    private final String serverUrl;
+    private final ClientTokenHolder tokenHolder;
+    private final TokenManager tokenManager;
+
+    @Autowired
+    public ProfileService(RestTemplate restTemplate,
+                          @Qualifier("serverUrl") String serverUrl,
+                          ClientTokenHolder tokenHolder,
+                          TokenManager tokenManager) {
+        this.restTemplate = restTemplate;
+        this.serverUrl = serverUrl.endsWith("/") ? serverUrl : serverUrl + "/";
+        this.tokenHolder = tokenHolder;
+        this.tokenManager = tokenManager;
+    }
+
+    public ProfileService(RestTemplate restTemplate,
+                          @Qualifier("serverUrl") String serverUrl,
+                          ClientTokenHolder tokenHolder) {
+        this(restTemplate, serverUrl, tokenHolder, new TokenManager(tokenHolder));
+    }
+
+    public UsernameDTO getUsername() {
+        var response = restTemplate.exchange(
+                serverUrl + "api/profile/username",
+                HttpMethod.GET,
+                new HttpEntity<>(tokenManager.authHeaders(tokenHolder)),
+                UsernameDTO.class
+        );
+        tokenManager.updateToken(tokenHolder, response);
+        return response.getBody();
+    }
+
+    public UsernameDTO updateUsername(@NotBlank String username) {
+        var response = restTemplate.exchange(
+                serverUrl + "api/profile/username",
+                HttpMethod.PUT,
+                new HttpEntity<>(new UsernameDTO(username), tokenManager.jsonHeaders(tokenHolder)),
+                UsernameDTO.class
+        );
+        tokenManager.updateToken(tokenHolder, response);
+        return response.getBody();
+    }
+
+    public ProfileDTO getProfile() {
+        var response = restTemplate.exchange(
+                serverUrl + "api/profile",
+                HttpMethod.GET,
+                new HttpEntity<>(tokenManager.authHeaders(tokenHolder)),
+                ProfileDTO.class
+        );
+        tokenManager.updateToken(tokenHolder, response);
+        return response.getBody();
+    }
+
+    public DetailedProfileStatsDTO getDetailedProfileStats() {
+        var response = restTemplate.exchange(
+                serverUrl + "api/profile/stats",
+                HttpMethod.GET,
+                new HttpEntity<>(tokenManager.authHeaders(tokenHolder)),
+                DetailedProfileStatsDTO.class
+        );
+        tokenManager.updateToken(tokenHolder, response);
+        return response.getBody();
+    }
+
+    public ProfileDTO updateProfile(@Valid ProfileDTO profileDTO) {
+        var response = restTemplate.postForEntity(
+                serverUrl + "api/profile",
+                new HttpEntity<>(profileDTO, tokenManager.jsonHeaders(tokenHolder)),
+                ProfileDTO.class
+        );
+        tokenManager.updateToken(tokenHolder, response);
+        return response.getBody();
+    }
+
+    public List<UserSessionDTO> getSessions() {
+        var response = restTemplate.exchange(
+                serverUrl + "api/profile/sessions",
+                HttpMethod.GET,
+                new HttpEntity<>(tokenManager.authHeaders(tokenHolder)),
+                new ParameterizedTypeReference<List<UserSessionDTO>>() {}
+        );
+        tokenManager.updateToken(tokenHolder, response);
+        return response.getBody();
+    }
+
+    public boolean deleteSession(UserSessionDTO session) {
+        var response = restTemplate.exchange(
+                serverUrl + "api/profile/sessions",
+                HttpMethod.DELETE,
+                new HttpEntity<>(session, tokenManager.jsonHeaders(tokenHolder)),
+                Void.class
+        );
+        tokenManager.updateToken(tokenHolder, response);
+        return response.getStatusCode().is2xxSuccessful();
+    }
+}

--- a/game-gateway/src/main/java/com/ultracards/gateway/service/ServerService.java
+++ b/game-gateway/src/main/java/com/ultracards/gateway/service/ServerService.java
@@ -23,12 +23,12 @@ public class ServerService {
     public ServerService(RestTemplate restTemplate,
                          @Qualifier("serverUrl")  String serverUrl) {
         this.restTemplate = restTemplate;
-        this.serverUrl = serverUrl;
+        this.serverUrl = serverUrl.endsWith("/") ? serverUrl : serverUrl + "/";
     }
 
     public ServerConnectionStatus isTheServerUp() {
 
-        var url = URI.create(serverUrl + "/active").toString();
+        var url = URI.create(serverUrl + "active").toString();
 
         try {
             var res = restTemplate.exchange(url, HttpMethod.GET, null, Void.class);

--- a/game-gateway/src/main/java/com/ultracards/gateway/service/StompGatewayService.java
+++ b/game-gateway/src/main/java/com/ultracards/gateway/service/StompGatewayService.java
@@ -1,0 +1,120 @@
+package com.ultracards.gateway.service;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.messaging.converter.JacksonJsonMessageConverter;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.util.function.Consumer;
+
+public abstract class StompGatewayService implements AutoCloseable {
+    private final WebSocketStompClient stompClient;
+    private final ThreadPoolTaskScheduler scheduler;
+    private final String wsUrl;
+    private final ClientTokenHolder tokenHolder;
+    private final TokenManager tokenManager;
+    private StompSession session;
+
+    StompGatewayService(String wsUrl, ClientTokenHolder tokenHolder) {
+        this(wsUrl, tokenHolder, new TokenManager(tokenHolder));
+    }
+
+    StompGatewayService(String wsUrl, ClientTokenHolder tokenHolder, TokenManager tokenManager) {
+        this.wsUrl = wsUrl;
+        this.tokenHolder = tokenHolder;
+        this.tokenManager = tokenManager;
+        this.scheduler = new ThreadPoolTaskScheduler();
+        this.scheduler.initialize();
+        this.stompClient = new WebSocketStompClient(new StandardWebSocketClient());
+        this.stompClient.setTaskScheduler(scheduler);
+        this.stompClient.setMessageConverter(new JacksonJsonMessageConverter());
+    }
+
+    public void connect(Runnable onConnected, Consumer<Throwable> onError) {
+        var headers = new WebSocketHttpHeaders();
+        var token = tokenManager.tokenValue(tokenHolder);
+        if (token != null) {
+            headers.add("Cookie", "refreshToken=" + token);
+        }
+
+        stompClient.connectAsync(URI.create(wsUrl).toString(), headers, new StompSessionHandlerAdapter() {
+            @Override
+            public void afterConnected(StompSession stompSession, StompHeaders connectedHeaders) {
+                session = stompSession;
+                if (onConnected != null) onConnected.run();
+            }
+
+            @Override
+            public void handleTransportError(StompSession stompSession, Throwable ex) {
+                if (onError != null) onError.accept(ex);
+            }
+        });
+    }
+
+    public void disconnect() {
+        if (session != null && session.isConnected()) {
+            session.disconnect();
+        }
+        scheduler.shutdown();
+    }
+
+    @Override
+    public void close() {
+        disconnect();
+    }
+
+    protected void send(String destination, Object payload) {
+        ensureSession();
+        session.send(destination, payload);
+    }
+
+    protected <T> StompSession.Subscription subscribe(
+            String destination,
+            Class<T> payloadType,
+            Consumer<T> handler
+    ) {
+        return subscribe(destination, (Type) payloadType, handler);
+    }
+
+    protected <T> StompSession.Subscription subscribe(
+            String destination,
+            ParameterizedTypeReference<T> payloadType,
+            Consumer<T> handler
+    ) {
+        return subscribe(destination, payloadType.getType(), handler);
+    }
+
+    private <T> StompSession.Subscription subscribe(
+            String destination,
+            Type payloadType,
+            Consumer<T> handler
+    ) {
+        ensureSession();
+        return session.subscribe(destination, new StompFrameHandler() {
+            @Override
+            public Type getPayloadType(StompHeaders headers) {
+                return payloadType;
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public void handleFrame(StompHeaders headers, Object payload) {
+                handler.accept((T) payload);
+            }
+        });
+    }
+
+    private void ensureSession() {
+        if (session == null || !session.isConnected()) {
+            throw new IllegalStateException("WebSocket session is not connected; call connect() first.");
+        }
+    }
+}

--- a/game-gateway/src/main/java/com/ultracards/gateway/service/UiPageService.java
+++ b/game-gateway/src/main/java/com/ultracards/gateway/service/UiPageService.java
@@ -1,0 +1,94 @@
+package com.ultracards.gateway.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.UUID;
+
+@Service
+public class UiPageService {
+    private final RestTemplate restTemplate;
+    private final String serverUrl;
+    private final ClientTokenHolder tokenHolder;
+    private final TokenManager tokenManager;
+
+    @Autowired
+    public UiPageService(RestTemplate restTemplate,
+                         @Qualifier("serverUrl") String serverUrl,
+                         ClientTokenHolder tokenHolder,
+                         TokenManager tokenManager) {
+        this.restTemplate = restTemplate;
+        this.serverUrl = serverUrl.endsWith("/") ? serverUrl : serverUrl + "/";
+        this.tokenHolder = tokenHolder;
+        this.tokenManager = tokenManager;
+    }
+
+    public UiPageService(RestTemplate restTemplate,
+                         @Qualifier("serverUrl") String serverUrl,
+                         ClientTokenHolder tokenHolder) {
+        this(restTemplate, serverUrl, tokenHolder, new TokenManager(tokenHolder));
+    }
+
+    public String home() {
+        return get("");
+    }
+
+    public String lobbies() {
+        return get("lobbies");
+    }
+
+    public String game() {
+        return get("game");
+    }
+
+    public String history() {
+        return get("history");
+    }
+
+    public String gameHistory(UUID gameId) {
+        return get("history/" + gameId);
+    }
+
+    public String profile() {
+        return get("profile");
+    }
+
+    public String error401() {
+        return get("errors/401");
+    }
+
+    public String error403() {
+        return get("errors/403");
+    }
+
+    public String error404() {
+        return get("errors/404");
+    }
+
+    public String error500() {
+        return get("errors/500");
+    }
+
+    public String sitemap() {
+        return get("sitemap.xml");
+    }
+
+    public String robots() {
+        return get("robots.txt");
+    }
+
+    private String get(String path) {
+        var response = restTemplate.exchange(
+                serverUrl + path,
+                HttpMethod.GET,
+                new HttpEntity<>(tokenManager.authHeaders(tokenHolder)),
+                String.class
+        );
+        tokenManager.updateToken(tokenHolder, response);
+        return response.getBody();
+    }
+}

--- a/game-gateway/src/main/java/com/ultracards/gateway/service/UserSearchService.java
+++ b/game-gateway/src/main/java/com/ultracards/gateway/service/UserSearchService.java
@@ -1,0 +1,58 @@
+package com.ultracards.gateway.service;
+
+import com.ultracards.gateway.dto.auth.ProfileDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+@Service
+public class UserSearchService {
+    private final RestTemplate restTemplate;
+    private final String serverUrl;
+
+    @Autowired
+    public UserSearchService(RestTemplate restTemplate,
+                             @Qualifier("serverUrl") String serverUrl) {
+        this.restTemplate = restTemplate;
+        this.serverUrl = serverUrl.endsWith("/") ? serverUrl : serverUrl + "/";
+    }
+
+    public List<ProfileDTO> searchUsersByUsername(String username) {
+        return searchUsersByUsername(username, null, null);
+    }
+
+    public List<ProfileDTO> searchUsersByUsername(String username, Integer lower, Integer higher) {
+        return search("username", username, lower, higher);
+    }
+
+    public List<ProfileDTO> searchUsersById(String id) {
+        return searchUsersById(id, null, null);
+    }
+
+    public List<ProfileDTO> searchUsersById(String id, Integer lower, Integer higher) {
+        return search("id", id, lower, higher);
+    }
+
+    public ProfileDTO getUserProfile(Long id) {
+        return restTemplate.getForObject(serverUrl + "api/users/" + id + "/profile", ProfileDTO.class);
+    }
+
+    private List<ProfileDTO> search(String type, String value, Integer lower, Integer higher) {
+        var url = serverUrl + "api/users/search/" + type + "/" + value;
+        if (lower != null && higher != null) {
+            url += "?lower=" + lower + "&higher=" + higher;
+        }
+        var response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<List<ProfileDTO>>() {}
+        );
+        return response.getBody();
+    }
+}

--- a/game-gateway/src/test/java/com/ultracards/gateway/app/GatewayTest.java
+++ b/game-gateway/src/test/java/com/ultracards/gateway/app/GatewayTest.java
@@ -1,0 +1,31 @@
+package com.ultracards.gateway.app;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+public final class GatewayTest {
+    private GatewayTest() {
+    }
+
+    static void main(String[] args) {
+        var state = new GatewayState<>("initial");
+        var seen = new AtomicReference<String>();
+        var listener = state.listen(seen::set);
+
+        state.set("updated");
+        assert "updated".equals(seen.get());
+
+        listener.close();
+        state.set("ignored");
+        assert "updated".equals(seen.get());
+
+        var async = GatewayAsync.direct();
+        assert "done".equals(async.call(() -> "done").join());
+
+        var uiSeen = new AtomicReference<String>();
+        async.onUi(CompletableFuture.completedFuture("ui"), uiSeen::set, error -> {
+            throw new AssertionError(error);
+        });
+        assert "ui".equals(uiSeen.get());
+    }
+}

--- a/server/src/main/java/com/ultracards/server/controllers/auth/ProfileController.java
+++ b/server/src/main/java/com/ultracards/server/controllers/auth/ProfileController.java
@@ -123,7 +123,7 @@ public class ProfileController {
     public ResponseEntity<?> deleteSessions(
             @AuthenticationPrincipal UserEntity user,
             @RequestAttribute("token") String token,
-            @Valid UserSessionDTO userSession
+            @RequestBody @Valid UserSessionDTO userSession
     ) {
         var deleteSession = sessionService.getSession(userSession.getId());
         if (deleteSession.getUserId().equals(user.getId())) {

--- a/ui/gui/pom.xml
+++ b/ui/gui/pom.xml
@@ -20,6 +20,13 @@
     </properties>
 
     <dependencies>
+        <!--        Gateway client dependencies       -->
+        <dependency>
+            <groupId>en1y.ultracards</groupId>
+            <artifactId>game-gateway</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!--        Games dependencies       -->
         <dependency>
             <groupId>en1y.ultracards.games</groupId>


### PR DESCRIPTION
- Added gateway REST and websocket coverage for server endpoints.
- Reworked deprecated websocket clients into shared STOMP-based services.
- Added UI-friendly app handles: `GatewayAppClient`, `GatewayAsync`, `GatewayState`, and subscription cleanup helpers.
- Updated `game-gateway` README with concise usage examples.